### PR TITLE
fix(ci): change workflow branch triggers from main to master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,13 +6,13 @@ name: Build
 
 on:
   push:
-    branches: [main, dev]
+    branches: [master, dev]
     paths:
       - "rust/**"
       - "pyproject.toml"
       - ".github/workflows/build.yml"
   pull_request:
-    branches: [main, dev]
+    branches: [master, dev]
     paths:
       - "rust/**"
       - "pyproject.toml"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,9 +7,9 @@ name: CodeQL
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
   schedule:
     # Run weekly on Monday at 6am UTC
     - cron: '0 6 * * 1'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,13 +9,13 @@ name: Docker
 
 on:
   push:
-    branches: [main]
+    branches: [master]
     tags:
       - "v*"
   # PR testing is handled by containers.yml using self-hosted Mac runner
   # Keeping this commented to avoid duplicate builds
   # pull_request:
-  #   branches: [main]
+  #   branches: [master]
   #   paths:
   #     - "Dockerfile"
   #     - "rust/**"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,14 +2,14 @@ name: Documentation
 
 on:
   push:
-    branches: [main]
+    branches: [master]
     paths:
       - 'docs/**'
       - 'src/**'
       - 'pyproject.toml'
       - '.github/workflows/docs.yml'
   pull_request:
-    branches: [main]
+    branches: [master]
     paths:
       - 'docs/**'
       - 'src/**'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,9 +29,9 @@ name: Security
 
 on:
   push:
-    branches: [main, dev]
+    branches: [master, dev]
   pull_request:
-    branches: [main, dev]
+    branches: [master, dev]
   schedule:
     - cron: '0 5 * * 1'  # Weekly Monday 5am UTC
 


### PR DESCRIPTION
## Summary

- Fix docs, docker, codeql, build, and security workflows that were triggering on `main` instead of `master` (the actual default branch)
- This is why the documentation site at mcvickerlab.github.io/WASP2/ was never deploying

## Test plan

- [ ] After merge, verify the docs workflow runs automatically (triggered by push to master with docs/ changes)
- [ ] Check https://mcvickerlab.github.io/WASP2/ comes online after workflow completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)