### PR TITLE
fix(docs): install deps without Rust build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,7 +53,24 @@ jobs:
       - name: Install documentation dependencies
         run: |
           pip install --upgrade pip
-          pip install -e ".[docs]"
+          # Install docs extras directly (avoids building the Rust extension)
+          pip install \
+            "sphinx>=7.0" \
+            "pydata-sphinx-theme>=0.15" \
+            "sphinx-autodoc-typehints>=1.25" \
+            "nbsphinx>=0.9" \
+            "myst-parser>=2.0" \
+            "sphinx-copybutton>=0.5" \
+            "sphinx-design>=0.5" \
+            "ipython>=8.0"
+          # Install core Python deps needed by autodoc (Rust ext is mocked in conf.py)
+          pip install \
+            "numpy>=1.21" \
+            "pandas>=1.5,<3.0" \
+            "polars>=0.19" \
+            "scipy>=1.10" \
+            "typer>=0.12" \
+            "rich>=13.0"
 
       - name: Build Sphinx documentation
         working-directory: docs

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -93,7 +93,7 @@ html_theme_options = {
 html_context = {
     "github_user": "mcvickerlab",
     "github_repo": "WASP2",
-    "github_version": "main",
+    "github_version": "master",
     "doc_path": "docs/source",
 }
 


### PR DESCRIPTION
## Summary
- Fix docs workflow failing because `pip install -e ".[docs]"` triggers maturin Rust build
- Install Sphinx and Python deps directly, bypassing the Rust extension build
- Fix `github_version` in conf.py from `main` to `master`

## Context
The docs workflow on `ubuntu-latest` doesn't have htslib/Rust deps installed. Since `conf.py` already mocks `wasp2_rust` via `autodoc_mock_imports`, the Rust extension isn't needed for documentation generation.

## Test plan
- [ ] Docs workflow completes successfully on merge
- [ ] GitHub Pages deploys at https://mcvickerlab.github.io/WASP2/

🤖 Generated with [Claude Code](https://claude.com/claude-code)