### PR TITLE
Phased ASE analysis + explicit region_col / per-variant grouping (Rust + CLI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to WASP2 will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- `--per-variant` / `--snv-solo` flag for `wasp2 analysis find_imbalance` to test each SNV
+  independently instead of grouping by a region column (forces per-variant even when a region
+  column is present; mutually exclusive with `--region_col`).
+
+### Changed
+- `--phased` and `--region_col` are now forwarded to the Rust analysis backend (previously parsed
+  but dropped, so the Rust path always ran unphased / feature-grouped).
+- `--groupby` now raises a clear error on the Rust analysis backend instead of being silently
+  ignored — it only re-keys the grouping column, so use `--region_col <parent_column>` for
+  parent-level grouping (identical result).
+
 ## [1.4.1] - 2026-04-18
 
 ### Changed
@@ -17,7 +31,7 @@ All notable changes to WASP2 will be documented in this file.
 - **14 verified bug fixes** across Python and Rust pipelines:
   - `not` → `~` on pandas Series for chromosome filtering (#50)
   - `samples[0]` truncation — pass full list instead of first element (#51)
-  - `--phased`/`--region_col`/`--groupby` forwarded to Rust analysis (#52)
+  - `--phased`/`--region_col` forwarded to Rust analysis (#52). (`--groupby` is **not** forwarded to the Rust backend; see Unreleased.)
   - `AttributeError` on `is_gene_file` when no feature file provided (#53)
   - `NameError` on `json_dict` in mapping pipeline (#54)
   - Dead expression in `compare_ai.py` snp_cutoff calculation (#55)

--- a/rust/src/analysis.rs
+++ b/rust/src/analysis.rs
@@ -9,7 +9,7 @@ use rayon::prelude::*;
 use rv::dist::BetaBinomial;
 use rv::traits::HasDensity;
 use statrs::distribution::{ChiSquared, ContinuousCDF};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 // ============================================================================
 // Data Structures
@@ -29,6 +29,19 @@ pub struct VariantCounts {
     /// Genotype phase relative to the reference allele: 0 = ref|alt, 1 = alt|ref.
     /// `None` when genotypes are absent or unphased. Required by phased analysis.
     pub gt: Option<u8>,
+}
+
+/// Deduplication key for matching Python's `df[keep_cols].drop_duplicates()`.
+/// Used to remove exact duplicate observations before analysis.
+#[derive(Hash, Eq, PartialEq)]
+struct DedupeKey {
+    chrom: String,
+    pos: u32,
+    region: String,
+    ref_count: u32,
+    alt_count: u32,
+    n: u32,
+    gt: Option<u8>, // Include GT when phased=true
 }
 
 /// Statistical results for a region
@@ -96,6 +109,31 @@ const RHO_EPSILON: f64 = 1e-10;
 #[inline]
 fn clamp_rho(rho: f64) -> f64 {
     rho.clamp(RHO_EPSILON, 1.0 - RHO_EPSILON)
+}
+
+/// Deduplicate variants to match Python's `df[keep_cols].drop_duplicates()`.
+///
+/// Python keeps columns: chrom, pos, ref_count, alt_count, N, region (+ GT if phased)
+/// and removes exact duplicate rows. This ensures parity with Python's behavior.
+fn deduplicate_variants(variants: Vec<VariantCounts>, phased: bool) -> Vec<VariantCounts> {
+    let mut seen: HashSet<DedupeKey> = HashSet::new();
+    let mut result = Vec::with_capacity(variants.len());
+
+    for v in variants {
+        let key = DedupeKey {
+            chrom: v.chrom.clone(),
+            pos: v.pos,
+            region: v.region.clone(),
+            ref_count: v.ref_count,
+            alt_count: v.alt_count,
+            n: v.ref_count + v.alt_count,
+            gt: if phased { v.gt } else { None },
+        };
+        if seen.insert(key) {
+            result.push(v);
+        }
+    }
+    result
 }
 
 /// Sigmoid function (inverse logit): expit(x) = 1 / (1 + e^-x)
@@ -1080,11 +1118,30 @@ pub fn analyze_imbalance(
 
     eprintln!("Processing {} variants after filtering", filtered.len());
 
+    // Deduplicate variants for Python parity (single and linear models only).
+    // Python's get_imbalance() does: df[keep_cols].drop_duplicates()
+    // Per-donor model skips dedup as it's a Rust-only feature.
+    let deduped = if config.method != AnalysisMethod::PerDonor {
+        let before = filtered.len();
+        let after = deduplicate_variants(filtered, config.phased);
+        if after.len() < before {
+            eprintln!(
+                "Deduplicated {} → {} variants ({} duplicates removed)",
+                before,
+                after.len(),
+                before - after.len()
+            );
+        }
+        after
+    } else {
+        filtered
+    };
+
     // Run analysis based on method
     let mut results = match config.method {
-        AnalysisMethod::Single => single_model(filtered, config.phased)?,
-        AnalysisMethod::Linear => linear_model(filtered, config.phased)?,
-        AnalysisMethod::PerDonor => per_donor_model(filtered)?,
+        AnalysisMethod::Single => single_model(deduped, config.phased)?,
+        AnalysisMethod::Linear => linear_model(deduped, config.phased)?,
+        AnalysisMethod::PerDonor => per_donor_model(deduped)?,
     };
 
     // Remove pseudocounts from results

--- a/rust/src/analysis.rs
+++ b/rust/src/analysis.rs
@@ -26,6 +26,9 @@ pub struct VariantCounts {
     pub region: String,
     /// Donor/sample identifier; required only by the per_donor model.
     pub sample: Option<String>,
+    /// Genotype phase relative to the reference allele: 0 = ref|alt, 1 = alt|ref.
+    /// `None` when genotypes are absent or unphased. Required by phased analysis.
+    pub gt: Option<u8>,
 }
 
 /// Statistical results for a region
@@ -50,6 +53,7 @@ pub struct AnalysisConfig {
     pub min_count: u32,
     pub pseudocount: u32,
     pub method: AnalysisMethod,
+    pub phased: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -65,6 +69,7 @@ impl Default for AnalysisConfig {
             min_count: 10,
             pseudocount: 1,
             method: AnalysisMethod::Single,
+            phased: false,
         }
     }
 }
@@ -276,6 +281,141 @@ fn optimize_prob(ref_counts: &[u32], n_array: &[u32], disp: f64) -> Result<(f64,
     Ok((alt_ll, mu))
 }
 
+/// Optimize probability for phased data using known genotype phase.
+///
+/// Python equivalent: `parse_opt()` phased branch calling
+/// `minimize_scalar(opt_phased_new, ...)` in as_analysis.py (L213-256, L118-140).
+///
+/// The phase array is first normalized so the first SNP is the reference
+/// (`if gt[0] > 0 { gt = 1 - gt }`), matching Python's
+/// `if gt_array[0] > 0: gt_array = 1 - gt_array`. The objective then sums
+/// `opt_prob(|prob - gt_i|, disp, ref_i, n_i)` across the region and is
+/// minimized over `prob` in (0, 1).
+///
+/// # Arguments
+/// * `ref_counts` - Reference allele counts for the region
+/// * `n_array` - Total counts for the region
+/// * `gt_array` - Genotype phase per variant (0 or 1)
+/// * `disp` - Dispersion parameter (scalar; per-region as in single/linear alt path)
+///
+/// # Returns
+/// Tuple of (alt_ll, mu) - alternative-model log-likelihood and imbalance proportion
+fn optimize_prob_phased(
+    ref_counts: &[u32],
+    n_array: &[u32],
+    gt_array: &[u8],
+    disp: f64,
+) -> Result<(f64, f64)> {
+    // Normalize phase so the first SNP is with respect to ref (matches Python).
+    let flip = gt_array.first().is_some_and(|&g| g > 0);
+    let gt_norm: Vec<u8> = gt_array
+        .iter()
+        .map(|&g| if flip { 1 - g } else { g })
+        .collect();
+
+    // objective(prob) = Σ opt_prob(|prob - gt_i|, disp, ref_i, n_i)
+    let objective = |prob: f64| -> f64 {
+        let mut sum = 0.0;
+        for ((&k, &n), &g) in ref_counts.iter().zip(n_array.iter()).zip(gt_norm.iter()) {
+            let phased_prob = (prob - g as f64).abs();
+            match opt_prob(phased_prob, disp, k, n) {
+                Ok(nll) => sum += nll,
+                Err(_) => return f64::INFINITY,
+            }
+        }
+        sum
+    };
+
+    let mu = golden_section_search(objective, 0.0, 1.0, 1e-6)?;
+    let alt_ll = -objective(mu);
+    Ok((alt_ll, mu))
+}
+
+/// Optimize probability for unphased data using dynamic programming.
+///
+/// Python equivalent: `opt_unphased_dp()` in as_analysis.py
+///
+/// This marginalizes over unknown phase using dynamic programming. At each
+/// position after the first, we consider both phase possibilities and weight
+/// them equally (0.5 each), accumulating likelihood across the region.
+///
+/// # Arguments
+/// * `prob` - Probability parameter (0 to 1)
+/// * `disp` - Dispersion parameter(s). If slice length > 1, first element is for
+///   first position and remaining elements are for subsequent positions.
+/// * `first_ref` - Reference count for first position
+/// * `first_n` - Total count for first position
+/// * `phase_ref` - Reference counts for subsequent positions
+/// * `phase_n` - Total counts for subsequent positions
+///
+/// # Returns
+/// Negative log-likelihood value (for minimization)
+pub fn optimize_prob_unphased_dp(
+    prob: f64,
+    disp: &[f64],
+    first_ref: u32,
+    first_n: u32,
+    phase_ref: &[u32],
+    phase_n: &[u32],
+) -> Result<f64> {
+    // Split per-variant dispersion for first vs subsequent positions (linear model)
+    let (first_disp, phase_disp): (f64, &[f64]) = if disp.len() > 1 {
+        (disp[0], &disp[1..])
+    } else {
+        // Scalar dispersion: use same value for all positions
+        (disp[0], disp)
+    };
+
+    // Get likelihood of first position (negative log-likelihood)
+    let first_ll = opt_prob(prob, first_disp, first_ref, first_n)?;
+
+    // If no subsequent positions, just return first_ll
+    if phase_ref.is_empty() {
+        return Ok(first_ll);
+    }
+
+    // Compute likelihoods for subsequent positions under both phase hypotheses
+    // phase1_like: pmf with prob
+    // phase2_like: pmf with (1 - prob)
+    let mut prev_like: f64 = 1.0;
+
+    for (i, (&ref_count, &n)) in phase_ref.iter().zip(phase_n.iter()).enumerate() {
+        // Get dispersion for this position
+        let rho = if phase_disp.len() > 1 {
+            clamp_rho(phase_disp[i.min(phase_disp.len() - 1)])
+        } else {
+            clamp_rho(phase_disp[0])
+        };
+
+        // Phase 1: use prob
+        let alpha1 = prob * (1.0 - rho) / rho;
+        let beta1 = (1.0 - prob) * (1.0 - rho) / rho;
+        let bb1 = BetaBinomial::new(n, alpha1, beta1)
+            .context("Failed to create beta-binomial for phase1")?;
+        let p1 = bb1.f(&(ref_count as u64)); // pmf (not log)
+
+        // Phase 2: use (1 - prob)
+        let alpha2 = (1.0 - prob) * (1.0 - rho) / rho;
+        let beta2 = prob * (1.0 - rho) / rho;
+        let bb2 = BetaBinomial::new(n, alpha2, beta2)
+            .context("Failed to create beta-binomial for phase2")?;
+        let p2 = bb2.f(&(ref_count as u64)); // pmf (not log)
+
+        // DP update: marginalize over both phases with equal weight
+        let p1_combined = prev_like * p1;
+        let p2_combined = prev_like * p2;
+        prev_like = 0.5 * p1_combined + 0.5 * p2_combined;
+    }
+
+    // Return first_ll + (-ln(prev_like))
+    // Handle edge case where prev_like might be 0 or very small
+    if prev_like <= 0.0 || !prev_like.is_finite() {
+        return Ok(f64::INFINITY);
+    }
+
+    Ok(first_ll + (-prev_like.ln()))
+}
+
 /// Golden section search for 1D optimization
 ///
 /// Simple but robust method for bounded scalar optimization.
@@ -467,7 +607,7 @@ pub fn fdr_correction(pvals: &[f64]) -> Vec<f64> {
 /// Single dispersion model analysis
 ///
 /// Python equivalent: `single_model()` in as_analysis.py
-pub fn single_model(variants: Vec<VariantCounts>) -> Result<Vec<ImbalanceResult>> {
+pub fn single_model(variants: Vec<VariantCounts>, phased: bool) -> Result<Vec<ImbalanceResult>> {
     if variants.is_empty() {
         return Ok(vec![]);
     }
@@ -510,8 +650,44 @@ pub fn single_model(variants: Vec<VariantCounts>) -> Result<Vec<ImbalanceResult>
             // Null model: prob = 0.5 (no imbalance)
             let null_ll = betabinom_logpmf_sum(&region_ref, &region_n, null_param, null_param)?;
 
-            // Alternative model: optimize prob
-            let (alt_ll, mu) = optimize_prob(&region_ref, &region_n, disp)?;
+            // Alternative model: optimize prob (phase-aware routing)
+            let all_gt = indices.iter().all(|&i| variants[i].gt.is_some());
+            let (alt_ll, mu) = if phased && indices.len() > 1 && all_gt {
+                // Phased multi-SNP region: use known genotype phase.
+                let region_gt: Vec<u8> = indices
+                    .iter()
+                    .map(|&i| variants[i].gt.expect("gt present (checked by all_gt)"))
+                    .collect();
+                optimize_prob_phased(&region_ref, &region_n, &region_gt, disp)?
+            } else if !phased && indices.len() > 1 {
+                // Unphased multi-SNP region: marginalize over phase via DP,
+                // minimizing opt_unphased_dp over prob in (0, 1)
+                // (first = index 0, phase = remaining), matching Python's
+                // parse_opt() unphased branch (minimize_scalar(opt_unphased_dp,...)).
+                let disp_slice = [disp];
+                let first_ref = region_ref[0];
+                let first_n = region_n[0];
+                let phase_ref = &region_ref[1..];
+                let phase_n = &region_n[1..];
+                let objective = |prob: f64| -> f64 {
+                    match optimize_prob_unphased_dp(
+                        prob,
+                        &disp_slice,
+                        first_ref,
+                        first_n,
+                        phase_ref,
+                        phase_n,
+                    ) {
+                        Ok(nll) => nll,
+                        Err(_) => f64::INFINITY,
+                    }
+                };
+                let mu = golden_section_search(objective, 0.0, 1.0, 1e-6)?;
+                let alt_ll = -objective(mu);
+                (alt_ll, mu)
+            } else {
+                optimize_prob(&region_ref, &region_n, disp)?
+            };
 
             // Likelihood ratio test
             let lrt = -2.0 * (null_ll - alt_ll);
@@ -561,7 +737,7 @@ pub fn single_model(variants: Vec<VariantCounts>) -> Result<Vec<ImbalanceResult>
 ///
 /// Python equivalent: `linear_model()` in as_analysis.py
 /// Uses ρ = expit(d1 + N × d2) where d1, d2 are globally optimized parameters.
-pub fn linear_model(variants: Vec<VariantCounts>) -> Result<Vec<ImbalanceResult>> {
+pub fn linear_model(variants: Vec<VariantCounts>, phased: bool) -> Result<Vec<ImbalanceResult>> {
     if variants.is_empty() {
         return Ok(vec![]);
     }
@@ -624,7 +800,45 @@ pub fn linear_model(variants: Vec<VariantCounts>) -> Result<Vec<ImbalanceResult>
             // Alternative model: optimize prob using per-variant rho
             // For simplicity, use average rho for optimization (matches Python behavior)
             let avg_rho = region_rho.iter().sum::<f64>() / region_rho.len() as f64;
-            let (alt_ll, mu) = optimize_prob(&region_ref, &region_n, avg_rho)?;
+            // Phase-aware routing (disp = avg_rho scalar, matching the existing
+            // single/linear alt path).
+            let all_gt = indices.iter().all(|&i| variants[i].gt.is_some());
+            let (alt_ll, mu) = if phased && indices.len() > 1 && all_gt {
+                // Phased multi-SNP region: use known genotype phase.
+                let region_gt: Vec<u8> = indices
+                    .iter()
+                    .map(|&i| variants[i].gt.expect("gt present (checked by all_gt)"))
+                    .collect();
+                optimize_prob_phased(&region_ref, &region_n, &region_gt, avg_rho)?
+            } else if !phased && indices.len() > 1 {
+                // Unphased multi-SNP region: marginalize over phase via DP,
+                // minimizing opt_unphased_dp over prob in (0, 1)
+                // (first = index 0, phase = remaining), matching Python's
+                // parse_opt() unphased branch (minimize_scalar(opt_unphased_dp,...)).
+                let disp_slice = [avg_rho];
+                let first_ref = region_ref[0];
+                let first_n = region_n[0];
+                let phase_ref = &region_ref[1..];
+                let phase_n = &region_n[1..];
+                let objective = |prob: f64| -> f64 {
+                    match optimize_prob_unphased_dp(
+                        prob,
+                        &disp_slice,
+                        first_ref,
+                        first_n,
+                        phase_ref,
+                        phase_n,
+                    ) {
+                        Ok(nll) => nll,
+                        Err(_) => f64::INFINITY,
+                    }
+                };
+                let mu = golden_section_search(objective, 0.0, 1.0, 1e-6)?;
+                let alt_ll = -objective(mu);
+                (alt_ll, mu)
+            } else {
+                optimize_prob(&region_ref, &region_n, avg_rho)?
+            };
 
             // Likelihood ratio test
             let lrt = -2.0 * (null_ll - alt_ll);
@@ -868,8 +1082,8 @@ pub fn analyze_imbalance(
 
     // Run analysis based on method
     let mut results = match config.method {
-        AnalysisMethod::Single => single_model(filtered)?,
-        AnalysisMethod::Linear => linear_model(filtered)?,
+        AnalysisMethod::Single => single_model(filtered, config.phased)?,
+        AnalysisMethod::Linear => linear_model(filtered, config.phased)?,
         AnalysisMethod::PerDonor => per_donor_model(filtered)?,
     };
 
@@ -966,5 +1180,61 @@ mod tests {
         let f = |x: f64| (x - 0.7).powi(2);
         let min = golden_section_search(f, 0.0, 1.0, 1e-6).unwrap();
         assert!((min - 0.7).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_optimize_prob_unphased_dp_single_position() {
+        // Test with only first position (no subsequent positions)
+        let disp = vec![0.1];
+        let result = optimize_prob_unphased_dp(0.5, &disp, 10, 20, &[], &[]).unwrap();
+        // Should just return first_ll from opt_prob
+        let expected = opt_prob(0.5, 0.1, 10, 20).unwrap();
+        assert!(
+            (result - expected).abs() < 1e-10,
+            "Single position: result={}, expected={}",
+            result,
+            expected
+        );
+    }
+
+    #[test]
+    fn test_optimize_prob_unphased_dp_multiple_positions() {
+        // Test with multiple positions
+        let disp = vec![0.1];
+        let phase_ref = vec![8, 12];
+        let phase_n = vec![20, 25];
+        let result = optimize_prob_unphased_dp(0.5, &disp, 10, 20, &phase_ref, &phase_n).unwrap();
+        // Result should be finite and positive
+        assert!(result.is_finite(), "Result should be finite");
+        assert!(result > 0.0, "Negative log-likelihood should be positive");
+    }
+
+    #[test]
+    fn test_optimize_prob_unphased_dp_per_variant_disp() {
+        // Test with per-variant dispersion (linear model)
+        let disp = vec![0.1, 0.15, 0.2]; // first pos: 0.1, subsequent: [0.15, 0.2]
+        let phase_ref = vec![8, 12];
+        let phase_n = vec![20, 25];
+        let result = optimize_prob_unphased_dp(0.5, &disp, 10, 20, &phase_ref, &phase_n).unwrap();
+        assert!(
+            result.is_finite(),
+            "Result should be finite with per-variant disp"
+        );
+        assert!(result > 0.0, "Negative log-likelihood should be positive");
+    }
+
+    #[test]
+    fn test_optimize_prob_unphased_dp_asymmetric_prob() {
+        // Test with asymmetric probability (imbalance)
+        let disp = vec![0.1];
+        let phase_ref = vec![15, 18]; // More ref alleles
+        let phase_n = vec![20, 25];
+        let result_balanced =
+            optimize_prob_unphased_dp(0.5, &disp, 10, 20, &phase_ref, &phase_n).unwrap();
+        let result_imbalanced =
+            optimize_prob_unphased_dp(0.7, &disp, 14, 20, &phase_ref, &phase_n).unwrap();
+        // Both should be finite
+        assert!(result_balanced.is_finite());
+        assert!(result_imbalanced.is_finite());
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -255,7 +255,7 @@ fn remap_all_chromosomes(
 ///     print(f"{r['region']}: pval={r['pval']:.4f}")
 /// ```
 #[pyfunction]
-#[pyo3(signature = (tsv_path, min_count=10, pseudocount=1, method="single", phased=false))]
+#[pyo3(signature = (tsv_path, min_count=10, pseudocount=1, method="single", phased=false, region_col=None))]
 fn analyze_imbalance(
     py: Python,
     tsv_path: &str,
@@ -263,6 +263,7 @@ fn analyze_imbalance(
     pseudocount: u32,
     method: &str,
     phased: bool,
+    region_col: Option<String>,
 ) -> PyResult<Py<PyAny>> {
     use pyo3::types::{PyDict, PyList};
     use std::fs::File;
@@ -327,8 +328,21 @@ fn analyze_imbalance(
             }
             // Detect an optional `sample` column by name (per_donor input)
             sample_idx = headers.iter().position(|h| *h == "sample");
-            // Detect a `region` column to use input region names for grouping
-            region_idx = headers.iter().position(|h| *h == "region");
+            // Resolve grouping column from the region_col argument (mirror Python get_imbalance):
+            //   Some(name) => group by that column (error if the column is absent)
+            //   None       => per-variant grouping (chrom_pos), ignoring any "region" column
+            region_idx = match &region_col {
+                Some(name) => match headers.iter().position(|h| *h == name.as_str()) {
+                    Some(ix) => Some(ix),
+                    None => {
+                        return Err(PyRuntimeError::new_err(format!(
+                            "region_col '{}' not found in header columns: {:?}",
+                            name, headers
+                        )))
+                    }
+                },
+                None => None,
+            };
             continue;
         }
 
@@ -348,13 +362,14 @@ fn analyze_imbalance(
             .parse::<u32>()
             .map_err(|e| PyRuntimeError::new_err(format!("Invalid alt_count: {}", e)))?;
 
-        // Use input region column if present, otherwise create chrom_pos_pos+1 format
+        // region_col=Some => use that column verbatim; region_col=None => per-variant chrom_pos.
+        // The chrom_pos label matches Python's df["chrom"] + "_" + df["pos"] for SNV-solo parity.
         let region = match region_idx {
             Some(ri) => fields
                 .get(ri)
                 .map(|s| s.to_string())
-                .unwrap_or_else(|| format!("{}_{}_{}", chrom, pos, pos + 1)),
-            None => format!("{}_{}_{}", chrom, pos, pos + 1),
+                .unwrap_or_else(|| format!("{}_{}", chrom, pos)),
+            None => format!("{}_{}", chrom, pos),
         };
 
         let sample = sample_idx.and_then(|si| fields.get(si).map(|s| s.to_string()));

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -255,13 +255,14 @@ fn remap_all_chromosomes(
 ///     print(f"{r['region']}: pval={r['pval']:.4f}")
 /// ```
 #[pyfunction]
-#[pyo3(signature = (tsv_path, min_count=10, pseudocount=1, method="single"))]
+#[pyo3(signature = (tsv_path, min_count=10, pseudocount=1, method="single", phased=false))]
 fn analyze_imbalance(
     py: Python,
     tsv_path: &str,
     min_count: u32,
     pseudocount: u32,
     method: &str,
+    phased: bool,
 ) -> PyResult<Py<PyAny>> {
     use pyo3::types::{PyDict, PyList};
     use std::fs::File;
@@ -284,6 +285,7 @@ fn analyze_imbalance(
         min_count,
         pseudocount,
         method: analysis_method,
+        phased,
     };
 
     // Read TSV file
@@ -300,6 +302,10 @@ fn analyze_imbalance(
     let mut ref_count_idx: usize = 4;
     let mut alt_count_idx: usize = 5;
     let mut min_fields: usize = 7;
+    // GT column index (only present in 9-col format)
+    let mut gt_idx: Option<usize> = None;
+    // Region column index (use input region names instead of chrom_pos format)
+    let mut region_idx: Option<usize> = None;
     // Optional donor/sample column (used by the per_donor model)
     let mut sample_idx: Option<usize> = None;
     let mut header_seen = false;
@@ -317,9 +323,12 @@ fn analyze_imbalance(
                 ref_count_idx = 6;
                 alt_count_idx = 7;
                 min_fields = 9;
+                gt_idx = Some(5);
             }
             // Detect an optional `sample` column by name (per_donor input)
             sample_idx = headers.iter().position(|h| *h == "sample");
+            // Detect a `region` column to use input region names for grouping
+            region_idx = headers.iter().position(|h| *h == "region");
             continue;
         }
 
@@ -339,10 +348,26 @@ fn analyze_imbalance(
             .parse::<u32>()
             .map_err(|e| PyRuntimeError::new_err(format!("Invalid alt_count: {}", e)))?;
 
-        // Create region identifier (chrom_pos_pos+1 format to match Python)
-        let region = format!("{}_{}_{}", chrom, pos, pos + 1);
+        // Use input region column if present, otherwise create chrom_pos_pos+1 format
+        let region = match region_idx {
+            Some(ri) => fields
+                .get(ri)
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| format!("{}_{}_{}", chrom, pos, pos + 1)),
+            None => format!("{}_{}_{}", chrom, pos, pos + 1),
+        };
 
         let sample = sample_idx.and_then(|si| fields.get(si).map(|s| s.to_string()));
+
+        // Parse the phased genotype (GT) column when present.
+        // Only fully-phased hets map to a value; everything else (unphased,
+        // homozygous, missing) is None. Emits ONLY Some(0)/Some(1)/None so
+        // downstream `1 - g` on u8 never underflows.
+        let gt: Option<u8> = gt_idx.and_then(|gi| match fields.get(gi) {
+            Some(&"0|1") => Some(0),
+            Some(&"1|0") => Some(1),
+            _ => None,
+        });
 
         variants.push(analysis::VariantCounts {
             chrom,
@@ -351,6 +376,7 @@ fn analyze_imbalance(
             alt_count,
             region,
             sample,
+            gt,
         });
     }
 

--- a/rust/src/multi_sample.rs
+++ b/rust/src/multi_sample.rs
@@ -1162,4 +1162,282 @@ mod tests {
         assert_eq!(&new_seq, b"AAGAAATAA");
         assert_eq!(new_qual.len(), 9);
     }
+
+    // ========================================================================
+    // Phased Output Comparison Tests
+    // ========================================================================
+    // These tests verify that CIGAR-aware allele substitution produces
+    // the correct phased output sequences for various variant types.
+
+    #[test]
+    fn test_phased_snp_ref_to_alt() {
+        // Given: A read with sequence "AAAAAAA" (7 bp)
+        // And: A SNP at position 3 where REF=A, ALT=G
+        // When: We apply the ALT allele
+        // Then: The output should be "AAAGAAA"
+
+        let seq = b"AAAAAAA".to_vec();
+        let qual = vec![30u8; 7];
+
+        let mut variant = make_test_variant(3, vec![("A", "G")]);
+        variant.ref_allele = "A".to_string();
+        variant.alt_allele = "G".to_string();
+        variant.vcf_stop = 4;
+        let variants: Vec<&VariantSpanMulti> = vec![&variant];
+        let alleles = vec!["G".to_string()];
+
+        let (ref2q_left, ref2q_right) =
+            make_position_maps(&[(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6)]);
+
+        let (new_seq, new_qual) = apply_allele_substitutions_cigar_aware(
+            &seq,
+            &qual,
+            &variants,
+            &alleles,
+            &ref2q_left,
+            &ref2q_right,
+        )
+        .expect("Substitution should succeed");
+
+        assert_eq!(&new_seq, b"AAAGAAA", "SNP substitution at position 3: A->G");
+        assert_eq!(new_qual.len(), 7, "Quality length unchanged for SNP");
+    }
+
+    #[test]
+    fn test_phased_snp_keeps_ref() {
+        // Given: A read with sequence "AAAGAAA" (7 bp)
+        // And: A SNP at position 3 where REF=A, ALT=G
+        // When: We apply the REF allele
+        // Then: The output should be "AAAAAAA"
+
+        let seq = b"AAAGAAA".to_vec();
+        let qual = vec![30u8; 7];
+
+        let mut variant = make_test_variant(3, vec![("A", "G")]);
+        variant.ref_allele = "A".to_string();
+        variant.alt_allele = "G".to_string();
+        variant.vcf_stop = 4;
+        let variants: Vec<&VariantSpanMulti> = vec![&variant];
+        let alleles = vec!["A".to_string()]; // Keep REF
+
+        let (ref2q_left, ref2q_right) =
+            make_position_maps(&[(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6)]);
+
+        let (new_seq, new_qual) = apply_allele_substitutions_cigar_aware(
+            &seq,
+            &qual,
+            &variants,
+            &alleles,
+            &ref2q_left,
+            &ref2q_right,
+        )
+        .expect("Substitution should succeed");
+
+        assert_eq!(
+            &new_seq, b"AAAAAAA",
+            "REF allele A replaces G at position 3"
+        );
+        assert_eq!(new_qual.len(), 7, "Quality length unchanged for SNP");
+    }
+
+    #[test]
+    fn test_phased_deletion_cgt_to_c() {
+        // Given: A read with sequence "AAACGTAAA" (9 bp)
+        // And: A deletion at positions 3-5 where REF=CGT, ALT=C
+        // When: We apply the ALT allele (deletion)
+        // Then: The output should be "AAACAAA" (7 bp)
+
+        let seq = b"AAACGTAAA".to_vec();
+        let qual = vec![30u8; 9];
+
+        let mut variant = make_test_variant(3, vec![("CGT", "C")]);
+        variant.ref_allele = "CGT".to_string();
+        variant.alt_allele = "C".to_string();
+        variant.vcf_stop = 6;
+        let variants: Vec<&VariantSpanMulti> = vec![&variant];
+        let alleles = vec!["C".to_string()];
+
+        let (ref2q_left, ref2q_right) = make_position_maps(&[
+            (0, 0),
+            (1, 1),
+            (2, 2),
+            (3, 3),
+            (4, 4),
+            (5, 5),
+            (6, 6),
+            (7, 7),
+            (8, 8),
+        ]);
+
+        let (new_seq, new_qual) = apply_allele_substitutions_cigar_aware(
+            &seq,
+            &qual,
+            &variants,
+            &alleles,
+            &ref2q_left,
+            &ref2q_right,
+        )
+        .expect("Substitution should succeed");
+
+        assert_eq!(&new_seq, b"AAACAAA", "Deletion CGT->C at position 3");
+        assert_eq!(
+            new_qual.len(),
+            7,
+            "Quality length reduced by 2 for deletion"
+        );
+    }
+
+    #[test]
+    fn test_phased_insertion_a_to_acgt() {
+        // Given: A read with sequence "AAAAAAA" (7 bp)
+        // And: An insertion at position 3 where REF=A, ALT=ACGT
+        // When: We apply the ALT allele (insertion)
+        // Then: The output should be "AAAACGTAAA" (10 bp)
+
+        let seq = b"AAAAAAA".to_vec();
+        let qual = vec![30u8; 7];
+
+        let mut variant = make_test_variant(3, vec![("A", "ACGT")]);
+        variant.ref_allele = "A".to_string();
+        variant.alt_allele = "ACGT".to_string();
+        variant.vcf_stop = 4;
+        let variants: Vec<&VariantSpanMulti> = vec![&variant];
+        let alleles = vec!["ACGT".to_string()];
+
+        let (ref2q_left, ref2q_right) =
+            make_position_maps(&[(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6)]);
+
+        let (new_seq, new_qual) = apply_allele_substitutions_cigar_aware(
+            &seq,
+            &qual,
+            &variants,
+            &alleles,
+            &ref2q_left,
+            &ref2q_right,
+        )
+        .expect("Substitution should succeed");
+
+        assert_eq!(&new_seq, b"AAAACGTAAA", "Insertion A->ACGT at position 3");
+        assert_eq!(
+            new_qual.len(),
+            10,
+            "Quality length increased by 3 for insertion"
+        );
+    }
+
+    #[test]
+    fn test_expected_phased_haplotypes() {
+        // Integration test: Given a heterozygous variant with phased genotype 0|1,
+        // verify that haplotype 1 (REF) and haplotype 2 (ALT) are generated correctly.
+
+        // Scenario: Read covers variant C>T at position 5
+        // Input read: "AAAAACAAAA" (has REF allele C at position 5)
+        // Expected hap1 (REF): "AAAAACAAAA"
+        // Expected hap2 (ALT): "AAAAATAAAA"
+
+        let seq = b"AAAAACAAAA".to_vec();
+        let qual = vec![30u8; 10];
+
+        let mut variant = make_test_variant(5, vec![("C", "T")]);
+        variant.ref_allele = "C".to_string();
+        variant.alt_allele = "T".to_string();
+        variant.vcf_stop = 6;
+        let variants: Vec<&VariantSpanMulti> = vec![&variant];
+
+        let (ref2q_left, ref2q_right) = make_position_maps(&[
+            (0, 0),
+            (1, 1),
+            (2, 2),
+            (3, 3),
+            (4, 4),
+            (5, 5),
+            (6, 6),
+            (7, 7),
+            (8, 8),
+            (9, 9),
+        ]);
+
+        // Haplotype 1: REF allele
+        let hap1_alleles = vec!["C".to_string()];
+        let (hap1_seq, _) = apply_allele_substitutions_cigar_aware(
+            &seq,
+            &qual,
+            &variants,
+            &hap1_alleles,
+            &ref2q_left,
+            &ref2q_right,
+        )
+        .expect("Haplotype 1 substitution should succeed");
+
+        // Haplotype 2: ALT allele
+        let hap2_alleles = vec!["T".to_string()];
+        let (hap2_seq, _) = apply_allele_substitutions_cigar_aware(
+            &seq,
+            &qual,
+            &variants,
+            &hap2_alleles,
+            &ref2q_left,
+            &ref2q_right,
+        )
+        .expect("Haplotype 2 substitution should succeed");
+
+        assert_eq!(
+            &hap1_seq, b"AAAAACAAAA",
+            "Haplotype 1 (REF) has C at position 5"
+        );
+        assert_eq!(
+            &hap2_seq, b"AAAAATAAAA",
+            "Haplotype 2 (ALT) has T at position 5"
+        );
+    }
+
+    #[test]
+    fn test_indel_coordinate_shift_with_deletion() {
+        // Test that variants downstream of a deletion are correctly placed
+        // even when query coordinates differ from reference coordinates.
+
+        // Scenario: Read with deletion in CIGAR (5M2D5M)
+        // Read sequence: "AAAAABBBBB" (10 bp aligned to 12 ref bp due to deletion)
+        // Variant at ref position 7 should map to query position 5.
+
+        let seq = b"AAAAABBBBB".to_vec();
+        let qual = vec![30u8; 10];
+
+        let mut variant = make_test_variant(7, vec![("B", "X")]);
+        variant.ref_allele = "B".to_string();
+        variant.alt_allele = "X".to_string();
+        variant.vcf_stop = 8;
+        let variants: Vec<&VariantSpanMulti> = vec![&variant];
+        let alleles = vec!["X".to_string()];
+
+        // Position mapping with deletion at ref 5-6
+        let (ref2q_left, ref2q_right) = make_position_maps(&[
+            (0, 0),
+            (1, 1),
+            (2, 2),
+            (3, 3),
+            (4, 4),
+            (7, 5),
+            (8, 6),
+            (9, 7),
+            (10, 8),
+            (11, 9),
+        ]);
+
+        let (new_seq, new_qual) = apply_allele_substitutions_cigar_aware(
+            &seq,
+            &qual,
+            &variants,
+            &alleles,
+            &ref2q_left,
+            &ref2q_right,
+        )
+        .expect("Substitution should succeed");
+
+        assert_eq!(
+            &new_seq, b"AAAAAXBBBB",
+            "Variant at ref 7 substitutes at query 5"
+        );
+        assert_eq!(new_qual.len(), 10, "Quality length unchanged");
+    }
 }

--- a/src/analysis/__main__.py
+++ b/src/analysis/__main__.py
@@ -129,6 +129,19 @@ def find_imbalance(
             ),
         ),
     ] = None,
+    per_variant: Annotated[
+        bool,
+        typer.Option(
+            "--per-variant",
+            "--snv-solo",
+            "--per_variant",
+            help=(
+                "Test each SNV independently (per-variant) instead of grouping by region/peak. "
+                "Forces per-variant even when a region column is present. "
+                "Cannot be combined with --region_col."
+            ),
+        ),
+    ] = False,
 ) -> None:
     run_ai_analysis(
         count_file=counts,
@@ -139,6 +152,7 @@ def find_imbalance(
         out_file=out_file,
         region_col=region_col,
         groupby=groupby,
+        per_variant=per_variant,
     )
 
 

--- a/src/analysis/run_analysis.py
+++ b/src/analysis/run_analysis.py
@@ -55,7 +55,17 @@ class WaspAnalysisData:
         out_file: str | None = None,
         region_col: str | None = None,
         groupby: str | None = None,
+        per_variant: bool = False,
     ) -> None:
+        # Per-variant (SNV-solo) mode cannot also name a region column: per-variant tests each
+        # SNV independently, whereas region_col groups variants by that column.
+        if per_variant and region_col is not None:
+            raise ValueError(
+                "per_variant cannot be combined with region_col: per-variant tests each SNV "
+                "independently, while region_col groups by that column. Choose one."
+            )
+        self.per_variant: bool = per_variant
+
         # User input data
         self.count_file = count_file
         self.region_col = region_col
@@ -91,8 +101,9 @@ class WaspAnalysisData:
             min_cols = 7
             region_idx = 4
 
-        # Check regions
-        if self.region_col is None:
+        # Check regions. Skip auto-detect in per-variant mode so region_col stays None
+        # (which the Rust backend interprets as per-variant chrom_pos grouping).
+        if self.region_col is None and not self.per_variant:
             if len(count_cols) > min_cols:
                 self.region_col = count_cols[region_idx]
 
@@ -126,6 +137,7 @@ def run_ai_analysis(
     out_file: str | None = None,
     region_col: str | None = None,
     groupby: str | None = None,
+    per_variant: bool = False,
 ) -> None:
     """Run allelic imbalance analysis pipeline.
 
@@ -146,13 +158,26 @@ def run_ai_analysis(
     region_col : str | None, optional
         Column name for grouping variants.
     groupby : str | None, optional
-        Additional grouping column.
+        Additional grouping column (not supported by the Rust backend; raises if set).
+    per_variant : bool, optional
+        Test each SNV independently (per-variant) instead of grouping by a region column.
+        Forces per-variant even when a region column is present. Default False.
 
     Raises
     ------
     RuntimeError
         If Rust analysis extension is not available.
     """
+    # Fail closed: --groupby is not supported by the Rust backend. It only re-keys the grouping
+    # column (region_col = groupby), so the identical result is obtained with --region_col <parent>.
+    # Erroring prevents silently returning feature-level results when parent-level was requested.
+    if groupby is not None:
+        raise RuntimeError(
+            "--groupby (parent-level grouping) is not supported by the Rust analysis backend. "
+            "Since groupby only re-keys the grouping column, group by the parent column directly "
+            "with --region_col <parent_column> instead."
+        )
+
     # Store analysis data and params
     ai_files = WaspAnalysisData(
         count_file,
@@ -163,17 +188,8 @@ def run_ai_analysis(
         out_file=out_file,
         region_col=region_col,
         groupby=groupby,
+        per_variant=per_variant,
     )
-
-    # Warn about params not yet forwarded to Rust backend.
-    # --phased and --region_col are now supported by the Rust backend and forwarded below;
-    # --groupby (parent-level secondary grouping) is not yet implemented in Rust.
-    unsupported = {
-        "--groupby": ai_files.groupby is not None,
-    }
-    for flag, active in unsupported.items():
-        if active:
-            logger.warning("%s is not yet supported by the Rust analysis backend; ignored", flag)
 
     # Run analysis pipeline (Rust only)
     if rust_analyze_imbalance is None:

--- a/src/analysis/run_analysis.py
+++ b/src/analysis/run_analysis.py
@@ -165,10 +165,10 @@ def run_ai_analysis(
         groupby=groupby,
     )
 
-    # Warn about params not yet forwarded to Rust backend
+    # Warn about params not yet forwarded to Rust backend.
+    # --phased and --region_col are now supported by the Rust backend and forwarded below;
+    # --groupby (parent-level secondary grouping) is not yet implemented in Rust.
     unsupported = {
-        "--phased": ai_files.phased,
-        "--region_col": ai_files.region_col is not None,
         "--groupby": ai_files.groupby is not None,
     }
     for flag, active in unsupported.items():
@@ -187,6 +187,8 @@ def run_ai_analysis(
         min_count=ai_files.min_count,
         pseudocount=ai_files.pseudocount,
         method=ai_files.model,
+        phased=ai_files.phased,
+        region_col=ai_files.region_col,
     )
     ai_df = pd.DataFrame(results)
 

--- a/tests/analysis/test_region_col_modes.py
+++ b/tests/analysis/test_region_col_modes.py
@@ -1,0 +1,181 @@
+"""Regression tests for region_col grouping modes + CLI flag forwarding.
+
+Covers the two grouping modes selectable via the Rust ``analyze_imbalance(region_col=...)``
+flag and the ``wasp2 analysis`` CLI plumbing in ``analysis.run_analysis``:
+
+* feature/peak mode (``region_col="region"``) groups variants within a region;
+* SNV-solo / per-variant mode (``region_col=None``) tests each SNV independently and
+  labels regions ``{chrom}_{pos}`` (must match Python's key for parity);
+* ``--per-variant`` forces per-variant even when a region column is present;
+* ``--per-variant`` + ``--region_col`` is rejected;
+* ``--groupby`` fails closed on the Rust backend (it only re-keys the grouping column,
+  so ``--region_col <parent>`` is the supported equivalent);
+* ``--phased`` / ``--region_col`` are forwarded to the Rust backend.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# --------------------------------------------------------------------------- helpers
+
+
+def _write_counts(path, *, with_region: bool = True):
+    """Write a tiny phased count TSV (two het SNVs in one peak).
+
+    ``with_region=True`` emits the 9-column layout that carries a ``region`` column;
+    ``with_region=False`` omits it. Only the header is consulted by ``WaspAnalysisData``.
+    """
+    if with_region:
+        header = "chrom\tstart\tpos\tref\tregion\tGT\tref_count\talt_count\tN\n"
+        rows = "chr1\t100\t101\tA\tpeakX\t0|1\t10\t8\t18\nchr1\t200\t201\tC\tpeakX\t1|0\t7\t9\t16\n"
+    else:
+        header = "chrom\tstart\tpos\tref\tGT\tref_count\talt_count\tN\n"
+        rows = "chr1\t100\t101\tA\t0|1\t10\t8\t18\nchr1\t200\t201\tC\t1|0\t7\t9\t16\n"
+    path.write_text(header + rows)
+    return path
+
+
+# --------------------------------------------------- Rust backend grouping modes
+
+
+@pytest.mark.rust
+def test_rust_feature_mode_groups_by_region(tmp_path):
+    """region_col='region' collapses both SNVs into one peak-level result."""
+    wasp2_rust = pytest.importorskip("wasp2_rust")
+    tsv = _write_counts(tmp_path / "counts.tsv")
+    res = wasp2_rust.analyze_imbalance(
+        str(tsv),
+        min_count=0,
+        pseudocount=0,
+        method="single",
+        phased=True,
+        region_col="region",
+    )
+    assert len(res) == 1
+    assert res[0]["region"] == "peakX"
+    assert res[0]["snp_count"] == 2
+    assert "mu" in res[0]  # phased model engaged
+
+
+@pytest.mark.rust
+def test_rust_solo_mode_per_variant_labels(tmp_path):
+    """region_col=None tests each SNV independently, labelled {chrom}_{pos}."""
+    wasp2_rust = pytest.importorskip("wasp2_rust")
+    tsv = _write_counts(tmp_path / "counts.tsv")
+    res = wasp2_rust.analyze_imbalance(
+        str(tsv),
+        min_count=0,
+        pseudocount=0,
+        method="single",
+        phased=True,
+        region_col=None,
+    )
+    regions = sorted(r["region"] for r in res)
+    # {chrom}_{pos} (matches Python's df["chrom"] + "_" + df["pos"]) — NOT chrom_start_pos.
+    assert regions == ["chr1_101", "chr1_201"]
+    assert all(r["snp_count"] == 1 for r in res)
+
+
+@pytest.mark.rust
+def test_rust_region_col_missing_raises(tmp_path):
+    """A region_col naming a column that is absent must error (fail closed)."""
+    wasp2_rust = pytest.importorskip("wasp2_rust")
+    tsv = _write_counts(tmp_path / "counts.tsv")
+    with pytest.raises(RuntimeError):
+        wasp2_rust.analyze_imbalance(
+            str(tsv),
+            min_count=0,
+            pseudocount=0,
+            method="single",
+            phased=True,
+            region_col="does_not_exist",
+        )
+
+
+# --------------------------------------------------- CLI plumbing (no extension)
+
+
+@pytest.fixture
+def spy_rust(monkeypatch):
+    """Replace run_analysis.rust_analyze_imbalance with a kwargs-capturing spy.
+
+    Setting it to a non-None callable also bypasses the "extension not available"
+    guard, so these tests run without the built Rust extension.
+    """
+    from analysis import run_analysis
+
+    captured: dict = {}
+
+    def _spy(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return [{"region": "x", "fdr_pval": 0.5}]  # minimal DataFrame-able result
+
+    monkeypatch.setattr(run_analysis, "rust_analyze_imbalance", _spy)
+    return captured
+
+
+@pytest.mark.unit
+def test_cli_forwards_phased_and_region_col(tmp_path, spy_rust):
+    from analysis.run_analysis import run_ai_analysis
+
+    tsv = _write_counts(tmp_path / "counts.tsv")
+    run_ai_analysis(
+        str(tsv),
+        min_count=0,
+        pseudocount=0,
+        phased=True,
+        region_col="region",
+        out_file=str(tmp_path / "out.tsv"),
+    )
+    assert spy_rust["kwargs"].get("phased") is True
+    assert spy_rust["kwargs"].get("region_col") == "region"
+
+
+@pytest.mark.unit
+def test_cli_groupby_fails_closed(tmp_path, spy_rust):
+    from analysis.run_analysis import run_ai_analysis
+
+    tsv = _write_counts(tmp_path / "counts.tsv")
+    with pytest.raises(RuntimeError, match="groupby"):
+        run_ai_analysis(
+            str(tsv),
+            min_count=0,
+            pseudocount=0,
+            groupby="parent",
+            out_file=str(tmp_path / "out.tsv"),
+        )
+
+
+@pytest.mark.unit
+def test_cli_per_variant_forces_solo(tmp_path, spy_rust):
+    from analysis.run_analysis import run_ai_analysis
+
+    # Region column IS present; --per-variant must still force region_col=None.
+    tsv = _write_counts(tmp_path / "counts.tsv", with_region=True)
+    run_ai_analysis(
+        str(tsv),
+        min_count=0,
+        pseudocount=0,
+        phased=True,
+        per_variant=True,
+        out_file=str(tmp_path / "out.tsv"),
+    )
+    assert spy_rust["kwargs"].get("region_col") is None
+
+
+@pytest.mark.unit
+def test_per_variant_region_col_conflict(tmp_path):
+    from analysis.run_analysis import run_ai_analysis
+
+    tsv = _write_counts(tmp_path / "counts.tsv")
+    with pytest.raises(ValueError):
+        run_ai_analysis(
+            str(tsv),
+            min_count=0,
+            pseudocount=0,
+            per_variant=True,
+            region_col="region",
+            out_file=str(tmp_path / "out.tsv"),
+        )


### PR DESCRIPTION
## Summary

Adds phased allele-specific expression (ASE) analysis to the Rust backend with verified parity to
the Python reference, and makes the variant-grouping mode an explicit, symmetric flag across both
the Rust library and the `wasp2 analysis` CLI.

## Changes

- **Phased ASE model (Rust)** — multi-SNP phased likelihood in `analyze_imbalance`
  (`rust/src/analysis.rs`, `rust/src/multi_sample.rs`).
- **Deduplication parity fix** — Rust now deduplicates variants to match Python's
  `df[keep_cols].drop_duplicates()`, so per-region counts / `snp_count` are byte-identical to the
  Python reference.
- **Explicit `region_col` flag (Rust)** — mirrors Python's `get_imbalance(region_col=...)`:
  `Some("region")` groups by that column (feature/peak mode); `None` tests each SNV independently
  (per-variant, labelled `{chrom}_{pos}` to match Python). Replaces the previous implicit auto-detect.
- **CLI plumbing** — `wasp2 analysis find_imbalance` now forwards `--phased` and `--region_col` to
  the Rust backend (previously parsed but dropped). Adds `--per-variant` / `--snv-solo` to force
  per-SNV grouping even when a region column is present (mutually exclusive with `--region_col`).
  `--groupby` now fails closed with a clear error (it only re-keys the grouping column — use
  `--region_col <parent>` for the identical result) instead of being silently ignored.
- **Tests** — `tests/analysis/test_region_col_modes.py`: feature vs per-variant grouping,
  region-label parity, missing-column error, CLI flag forwarding, fail-closed `--groupby`, and the
  per-variant / `--region_col` conflict.
- **CHANGELOG** updated; corrected a prior inaccurate entry.

## Verification

- `ruff check` + `ruff format --check`: clean.
- `pytest tests/analysis`: 7/7 pass (4 unit + 3 rust-marked against a freshly built extension).
- Python-vs-Rust parity benchmarks (137-donor cohort): ATAC dual-mode (feature 75,278 peaks +
  SNV-solo 160,178 variants) and RNA both PASS — counts bit-identical, identical significance calls,
  `lrt` / `pval` / `mu` within tolerance.

## Notes

- Parent-level `groupby` in the Rust backend is intentionally deferred (it only re-keys the grouping
  column; `--region_col <parent>` covers the use case). It now errors rather than silently returning
  feature-level results.
- No special build steps for reviewers beyond the standard `maturin develop --release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)