### PR TITLE
feat(counting): add locked donor-aware cohort bundles

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,12 +9,14 @@ on:
     branches: [master, dev]
     paths:
       - "rust/**"
+      - "src/**"
       - "pyproject.toml"
       - ".github/workflows/build.yml"
   pull_request:
     branches: [master, dev]
     paths:
       - "rust/**"
+      - "src/**"
       - "pyproject.toml"
       - ".github/workflows/build.yml"
 
@@ -82,6 +84,14 @@ jobs:
 
       - name: Build wheel with maturin
         run: maturin build --release -o dist/
+
+      - name: Install and smoke-test built wheel
+        run: |
+          uv venv /tmp/wasp2-wheel
+          uv pip install --python /tmp/wasp2-wheel/bin/python dist/*.whl
+          cd /tmp
+          /tmp/wasp2-wheel/bin/python -c "import wasp2_rust; print(wasp2_rust.__file__)"
+          /tmp/wasp2-wheel/bin/wasp2-count count-cohort --help
 
       - name: Upload wheel artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,8 @@ jobs:
             pkg-config \
             libclang-dev \
             samtools \
-            bcftools
+            bcftools \
+            bedtools
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,14 +2,14 @@ name: Documentation
 
 on:
   push:
-    branches: [master]
+    branches: [master, dev]
     paths:
       - 'docs/**'
       - 'src/**'
       - 'pyproject.toml'
       - '.github/workflows/docs.yml'
   pull_request:
-    branches: [master]
+    branches: [master, dev]
     paths:
       - 'docs/**'
       - 'src/**'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,8 +19,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: "pages-${{ github.ref }}"
@@ -77,16 +75,19 @@ jobs:
         run: make html
 
       - name: Upload artifact
-        if: github.event_name != 'pull_request'
+        if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b  # v4
         with:
           path: docs/build/html
 
   deploy:
-    if: github.event_name != 'pull_request'
+    if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ All notable changes to WASP2 will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- `wasp2-count count-cohort` for one-final-BAM-per-donor bulk counting with explicit
+  `donor_id`/`vcf_sample` mapping, atomic locked outputs, and SHA-256 provenance.
 - `--per-variant` / `--snv-solo` flag for `wasp2 analysis find_imbalance` to test each SNV
   independently instead of grouping by a region column (forces per-variant even when a region
   column is present; mutually exclusive with `--region_col`).
 
 ### Changed
+- Bulk counting now fails closed on chromosome-level Rust errors and stores allele counts as
+  `UInt32` to avoid truncating depths above 65,535.
 - `--phased` and `--region_col` are now forwarded to the Rust analysis backend (previously parsed
   but dropped, so the Rust path always ran unphased / feature-grouped).
 - `--groupby` now raises a clear error on the Rust analysis backend instead of being silently

--- a/README.md
+++ b/README.md
@@ -89,6 +89,25 @@ wasp2-map filter-remapped remapped.bam \
 wasp2-count count-variants filtered.bam variants.vcf.gz -s sample1 -o counts.tsv
 ```
 
+For a bulk cohort, use one final indexed BAM per donor and map donor identifiers
+to VCF sample names explicitly:
+
+```text
+donor_id	vcf_sample	bam
+donor1	VCF_sample_1	/path/to/donor1.bam
+donor2	VCF_sample_2	/path/to/donor2.bam
+```
+
+```bash
+wasp2-count count-cohort donors.tsv variants.vcf.gz cohort_counts \
+  --unit snv --regions atac_peaks.bed
+```
+
+This creates a new locked directory containing `counts.tsv.gz`, normalized
+`donors.tsv`, and `count_manifest.json`. In SNV mode, regions restrict included
+sites but do not combine their tests. Use `--unit feature --regions peaks.bed`
+to retain peak identifiers for feature-level analysis.
+
 ### 3. Test for imbalance
 
 ```bash

--- a/docs/source/api/counting.rst
+++ b/docs/source/api/counting.rst
@@ -44,6 +44,14 @@ run_counting
    :show-inheritance:
    :exclude-members: bam_file, variant_file, region_file, samples, out_file, temp_loc, variant_prefix, vcf_bed, skip_vcf_to_bed, region_type, is_gene_file, use_region_names, intersect_file, skip_intersect, gtf_bed
 
+run_counting_cohort
+-------------------
+
+.. automodule:: counting.run_counting_cohort
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 run_counting_sc
 ---------------
 

--- a/docs/source/user_guide/counting.rst
+++ b/docs/source/user_guide/counting.rst
@@ -7,9 +7,10 @@ Overview
 ``wasp2-count`` counts reads supporting reference and alternate alleles at
 variant positions in BAM files.
 
-It provides two commands:
+It provides three commands:
 
 * ``count-variants`` for bulk data
+* ``count-cohort`` for a locked bulk cohort with one final BAM per donor
 * ``count-variants-sc`` for single-cell data with ``CB``-tagged barcodes
 
 Bulk Counting
@@ -64,6 +65,45 @@ Output columns always include:
 
 When sample filtering is active, genotype columns are included. When region
 annotation is active, region or gene columns are included as well.
+
+Locked Cohort Counting
+----------------------
+
+``count-cohort`` makes the donor-to-VCF-to-BAM relationship explicit. Its
+manifest must contain exactly three tab-separated columns:
+
+.. code-block:: text
+
+   donor_id	vcf_sample	bam
+   donor1	VCF_sample_1	/path/to/donor1.bam
+   donor2	VCF_sample_2	/path/to/donor2.bam
+
+Each row must identify one final merged, WASP-filtered, deduplicated, indexed
+BAM. The cohort VCF must also be indexed and contain every ``vcf_sample``.
+The locked cohort path applies WASP2's standard biallelic-SNV selection:
+multi-allelic records and indels are excluded and that policy is recorded in
+``count_manifest.json``.
+
+Independent SNV counts restricted to ATAC peaks:
+
+.. code-block:: bash
+
+   wasp2-count count-cohort \
+     donors.tsv variants.vcf.gz cohort_snv_counts \
+     --unit snv --regions peaks.bed
+
+Peak-feature counts:
+
+.. code-block:: bash
+
+   wasp2-count count-cohort \
+     donors.tsv variants.vcf.gz cohort_feature_counts \
+     --unit feature --regions peaks.bed
+
+The command refuses to overwrite an existing output directory. It claims the
+directory atomically and publishes ``count_manifest.json`` last as the commit
+marker after hashing and rechecking every input. The count manifest is the
+authoritative entry point for downstream donor-aware analysis.
 
 Single-Cell ATAC Counting
 -------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,8 @@ dependencies = [
     "pysam>=0.21.0",
     "pybedtools>=0.9.0",
     "anndata>=0.8.0,<0.12.0",
-    "scanpy>=1.9.0",
+    "scanpy>=1.10.0",
+    "numba>=0.59.0",
     "typer>=0.12.0",
     "rich>=13.0.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,8 @@ scipy>=1.10.0
 pysam>=0.21.0
 pybedtools>=0.9.0
 anndata>=0.8.0,<0.12.0
-scanpy>=1.9.0
+scanpy>=1.10.0
+numba>=0.59.0
 
 # CLI
 typer>=0.12.0

--- a/src/counting/__main__.py
+++ b/src/counting/__main__.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Annotated
 
 import typer
@@ -5,7 +6,13 @@ import typer
 from wasp2.cli import create_version_callback, verbosity_callback
 
 from .run_counting import run_count_variants
-from .run_counting_sc import run_count_variants_sc
+from .run_counting_cohort import run_count_cohort
+
+
+class AnalysisUnitChoice(str, Enum):
+    snv = "snv"
+    feature = "feature"
+    peak = "peak"
 
 
 def _get_counting_deps() -> dict[str, str]:
@@ -219,6 +226,49 @@ def count_variants(
 
 
 @app.command()
+def count_cohort(
+    donor_manifest: Annotated[
+        str,
+        typer.Argument(help="TSV with exactly three columns: donor_id, vcf_sample, bam"),
+    ],
+    variants: Annotated[str, typer.Argument(help="Indexed cohort VCF.GZ, VCF.BGZ, or BCF")],
+    output_dir: Annotated[str, typer.Argument(help="New directory for locked count outputs")],
+    unit: Annotated[
+        AnalysisUnitChoice,
+        typer.Option("--unit", help="Statistical unit: independent SNVs or features."),
+    ],
+    region_file: Annotated[
+        str | None,
+        typer.Option(
+            "--regions",
+            "--region",
+            "-r",
+            help=("Optional SNV inclusion mask; required feature definitions in feature mode."),
+        ),
+    ] = None,
+    use_region_names: Annotated[
+        bool,
+        typer.Option(
+            "--use-region-names/--use-region-coordinates",
+            help="Use the fourth region column as the feature identifier.",
+        ),
+    ] = True,
+) -> None:
+    result = run_count_cohort(
+        donor_manifest=donor_manifest,
+        variant_file=variants,
+        output_dir=output_dir,
+        unit=unit.value,
+        region_file=region_file,
+        use_region_names=use_region_names,
+    )
+    typer.echo(
+        f"Locked {result['donors']} donors and {result['rows']} count rows in "
+        f"{result['output_dir']}"
+    )
+
+
+@app.command()
 def count_variants_sc(
     bam: Annotated[str, typer.Argument(help="BAM file")],
     variants: Annotated[str, typer.Argument(help="Variant file (VCF, VCF.GZ, BCF, or PGEN)")],
@@ -293,6 +343,8 @@ def count_variants_sc(
         ),
     ] = True,
 ) -> None:
+    from .run_counting_sc import run_count_variants_sc
+
     run_count_variants_sc(
         bam_file=bam,
         variant_file=variants,

--- a/src/counting/count_alleles.py
+++ b/src/counting/count_alleles.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 
 import polars as pl
 
-from wasp2.cli import create_progress, detail, error, rust_status, success
+from wasp2.cli import create_progress, detail, rust_status, success
 
 if TYPE_CHECKING:
     import pysam
@@ -124,16 +124,11 @@ def make_count_df(bam_file: str, df: pl.DataFrame, use_rust: bool = True) -> pl.
 
             start = timeit.default_timer()
 
-            try:
-                count_list.extend(
-                    count_snp_alleles_rust(bam_file, chrom, snp_list, threads=rust_threads)
-                )
-            except (RuntimeError, OSError) as e:
-                # Use error() not warning() - errors always shown even in quiet mode
-                error(f"Skipping {chrom}: {e}")
-            else:
-                elapsed = timeit.default_timer() - start
-                detail(f"{chrom}: Counted {chrom_df.height} SNPs in {elapsed:.2f}s")
+            count_list.extend(
+                count_snp_alleles_rust(bam_file, chrom, snp_list, threads=rust_threads)
+            )
+            elapsed = timeit.default_timer() - start
+            detail(f"{chrom}: Counted {chrom_df.height} SNPs in {elapsed:.2f}s")
 
             progress.update(task, advance=1)
 
@@ -148,9 +143,9 @@ def make_count_df(bam_file: str, df: pl.DataFrame, use_rust: bool = True) -> pl.
         schema={
             "chrom": chrom_enum,
             "pos": pl.UInt32,
-            "ref_count": pl.UInt16,
-            "alt_count": pl.UInt16,
-            "other_count": pl.UInt16,
+            "ref_count": pl.UInt32,
+            "alt_count": pl.UInt32,
+            "other_count": pl.UInt32,
         },
         orient="row",
     )

--- a/src/counting/run_counting_cohort.py
+++ b/src/counting/run_counting_cohort.py
@@ -1,0 +1,590 @@
+"""Locked allele counting for one final bulk BAM per donor."""
+
+from __future__ import annotations
+
+import csv
+import gzip
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Any, Literal
+
+import polars as pl
+import pysam
+
+from .run_counting import run_count_variants
+
+AnalysisUnit = Literal["snv", "feature"]
+SCHEMA_VERSION = "wasp2.count-bundle.v1"
+UTC = timezone.utc
+
+
+@dataclass(frozen=True)
+class DonorInput:
+    donor_id: str
+    vcf_sample: str
+    bam: Path
+    bam_index: Path
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _signature(path: Path) -> tuple[int, int, int, int]:
+    stat = path.stat()
+    return stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns
+
+
+def _require_unchanged(path: Path, signature: tuple[int, int, int, int]) -> None:
+    if _signature(path) != signature:
+        raise RuntimeError(f"Input changed while cohort counting was running: {path}")
+
+
+def _file_record(path: Path) -> tuple[dict[str, str | int], tuple[int, int, int, int]]:
+    resolved = path.resolve(strict=True)
+    before = _signature(resolved)
+    digest = _sha256(resolved)
+    _require_unchanged(resolved, before)
+    stat = resolved.stat()
+    return (
+        {
+            "path": str(resolved),
+            "sha256": digest,
+            "size_bytes": stat.st_size,
+        },
+        before,
+    )
+
+
+def _require_matching_hash(path: Path, expected_sha256: str) -> None:
+    if _sha256(path) != expected_sha256:
+        raise RuntimeError(f"Input content changed while cohort counting was running: {path}")
+
+
+def _bam_index(bam: Path) -> Path:
+    candidates = [
+        Path(f"{bam}.bai"),
+        bam.with_suffix(".bai"),
+        Path(f"{bam}.csi"),
+        bam.with_suffix(".csi"),
+    ]
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate.resolve(strict=True)
+    raise ValueError(f"Missing BAM index for {bam}; expected a BAI or CSI sidecar")
+
+
+def _validate_bam_index(bam: Path, index: Path) -> None:
+    try:
+        with pysam.AlignmentFile(str(bam), "rb", index_filename=str(index)) as alignment:
+            if not alignment.has_index() or not alignment.check_index():
+                raise ValueError(f"BAM index is not usable for {bam}")
+    except (OSError, ValueError) as error:
+        raise ValueError(f"Cannot open indexed BAM: {bam}") from error
+
+
+def _variant_index(variants: Path) -> Path:
+    name = variants.name.lower()
+    if not (name.endswith(".vcf.gz") or name.endswith(".vcf.bgz") or name.endswith(".bcf")):
+        raise ValueError("Cohort counting requires an indexed VCF.GZ, VCF.BGZ, or BCF file")
+    candidates = [Path(f"{variants}.csi"), Path(f"{variants}.tbi")]
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate.resolve(strict=True)
+    raise ValueError(f"Missing variant index for {variants}; expected .csi or .tbi sidecar")
+
+
+def _vcf_samples(variants: Path) -> set[str]:
+    try:
+        with pysam.VariantFile(str(variants)) as variant_file:
+            next(variant_file.fetch(), None)
+            return set(variant_file.header.samples)
+    except (OSError, ValueError) as error:
+        raise ValueError(f"Cannot read cohort variant file: {variants}") from error
+
+
+def _read_donor_manifest(path: Path, valid_vcf_samples: set[str]) -> list[DonorInput]:
+    with path.open(newline="") as handle:
+        reader = csv.DictReader(handle, delimiter="\t")
+        if reader.fieldnames != ["donor_id", "vcf_sample", "bam"]:
+            raise ValueError(
+                "Donor manifest must have exactly three columns: donor_id, vcf_sample, bam"
+            )
+        rows = list(reader)
+    if not rows:
+        raise ValueError("Donor manifest contains no donors")
+
+    donors: list[DonorInput] = []
+    seen_donors: set[str] = set()
+    seen_samples: set[str] = set()
+    seen_bams: set[Path] = set()
+    for line_number, row in enumerate(rows, start=2):
+        donor_id = row["donor_id"].strip()
+        vcf_sample = row["vcf_sample"].strip()
+        bam_value = row["bam"].strip()
+        if not donor_id or not vcf_sample or not bam_value:
+            raise ValueError(f"Empty donor_id, vcf_sample, or bam on manifest line {line_number}")
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", donor_id):
+            raise ValueError(f"Invalid donor_id: {donor_id!r}")
+        if any(character in vcf_sample for character in "\t\r\n"):
+            raise ValueError(f"Invalid vcf_sample: {vcf_sample!r}")
+        if donor_id in seen_donors:
+            raise ValueError(f"Duplicate donor_id in donor manifest: {donor_id}")
+        if vcf_sample in seen_samples:
+            raise ValueError(f"Duplicate vcf_sample in donor manifest: {vcf_sample}")
+        if vcf_sample not in valid_vcf_samples:
+            raise ValueError(f"VCF sample not found in cohort variant file: {vcf_sample}")
+
+        bam = Path(bam_value).expanduser()
+        if not bam.is_absolute():
+            bam = path.parent / bam
+        bam = bam.resolve(strict=True)
+        if bam.suffix.lower() != ".bam":
+            raise ValueError(f"Bulk cohort inputs must be BAM files: {bam}")
+        if bam in seen_bams:
+            raise ValueError(f"Each donor must have a distinct BAM: {bam}")
+
+        bam_index = _bam_index(bam)
+        _validate_bam_index(bam, bam_index)
+        donors.append(DonorInput(donor_id, vcf_sample, bam, bam_index))
+        seen_donors.add(donor_id)
+        seen_samples.add(vcf_sample)
+        seen_bams.add(bam)
+    return sorted(donors, key=lambda donor: donor.donor_id)
+
+
+def _package_version() -> str:
+    try:
+        return version("wasp2")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def _git_state() -> dict[str, str | bool | None]:
+    repository = Path(__file__).resolve().parents[2]
+    try:
+        revision = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repository,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        status = subprocess.run(
+            ["git", "status", "--porcelain", "--untracked-files=normal"],
+            cwd=repository,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return {"git_commit": None, "git_dirty": None}
+    commit = revision.stdout.strip()
+    return {
+        "git_commit": commit if re.fullmatch(r"[0-9a-f]{40}", commit) else None,
+        "git_dirty": bool(status.stdout.strip()),
+    }
+
+
+def _normalize_snv_rows(frame: pl.DataFrame, donor_id: str) -> pl.DataFrame:
+    required = {"chrom", "pos", "ref", "alt", "ref_count", "alt_count", "other_count"}
+    missing = sorted(required.difference(frame.columns))
+    if missing:
+        raise RuntimeError(f"Allele counter omitted required columns for {donor_id}: {missing}")
+
+    identity = ["chrom", "pos", "ref", "alt"]
+    compared = ["ref_count", "alt_count", "other_count"]
+    if "GT" in frame.columns:
+        compared.append("GT")
+    conflicts = frame.group_by(identity).agg(
+        [pl.col(column).n_unique().alias(f"n_{column}") for column in compared]
+    )
+    conflict_filter = pl.any_horizontal([pl.col(f"n_{column}") > 1 for column in compared])
+    if conflicts.filter(conflict_filter).height:
+        row = conflicts.filter(conflict_filter).row(0, named=True)
+        raise RuntimeError(
+            f"Conflicting count rows for {donor_id} "
+            f"{row['chrom']}:{row['pos']}:{row['ref']}>{row['alt']}"
+        )
+
+    columns = [
+        column
+        for column in [
+            "chrom",
+            "pos0",
+            "pos",
+            "ref",
+            "alt",
+            "GT",
+            "ref_count",
+            "alt_count",
+            "other_count",
+        ]
+        if column in frame.columns
+    ]
+    return (
+        frame.select(columns)
+        .unique(subset=identity, keep="first", maintain_order=True)
+        .with_columns(pl.lit(donor_id).alias("donor_id"))
+        .select(["donor_id", *columns])
+        .sort(["chrom", "pos", "ref", "alt"])
+    )
+
+
+def _normalize_feature_rows(frame: pl.DataFrame, donor_id: str) -> pl.DataFrame:
+    required = {
+        "chrom",
+        "pos",
+        "ref",
+        "alt",
+        "GT",
+        "region",
+        "ref_count",
+        "alt_count",
+        "other_count",
+    }
+    missing = sorted(required.difference(frame.columns))
+    if missing:
+        raise RuntimeError(f"Feature counter omitted required columns for {donor_id}: {missing}")
+    if frame.get_column("region").is_null().any() or (frame.get_column("region") == "").any():
+        raise RuntimeError(f"Feature counter produced an empty feature identifier for {donor_id}")
+    return (
+        frame.with_columns(pl.lit(donor_id).alias("donor_id"))
+        .select(["donor_id", *frame.columns])
+        .sort(["chrom", "pos", "ref", "alt", "region"])
+    )
+
+
+def _reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"Duplicate JSON key in count bundle manifest: {key}")
+        result[key] = value
+    return result
+
+
+def _validate_hash(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not re.fullmatch(r"[0-9a-f]{64}", value):
+        raise ValueError(f"Invalid SHA-256 for {label}")
+    return value
+
+
+def _bundle_member(bundle_dir: Path, record: dict[str, Any], expected_name: str) -> Path:
+    if record.get("path") != expected_name:
+        raise ValueError(f"Count bundle output path must be {expected_name}")
+    candidate = bundle_dir / expected_name
+    if candidate.is_symlink() or not candidate.is_file():
+        raise ValueError(f"Count bundle output must be a regular non-symlink file: {expected_name}")
+    return candidate
+
+
+def verify_count_bundle(
+    manifest_file: str | Path,
+    *,
+    expected_manifest_sha256: str | None = None,
+) -> dict[str, Any]:
+    """Verify locked count outputs and return the parsed manifest."""
+    manifest_input = Path(manifest_file).expanduser()
+    if manifest_input.is_symlink() or not manifest_input.is_file():
+        raise ValueError(
+            f"Count bundle manifest must be a regular non-symlink file: {manifest_input}"
+        )
+    manifest_path = manifest_input.resolve(strict=True)
+    if expected_manifest_sha256 is not None:
+        expected = _validate_hash(expected_manifest_sha256, "count bundle manifest")
+        if _sha256(manifest_path) != expected:
+            raise ValueError("Count bundle manifest failed expected SHA-256 verification")
+    try:
+        manifest = json.loads(
+            manifest_path.read_text(),
+            object_pairs_hook=_reject_duplicate_json_keys,
+        )
+    except (OSError, json.JSONDecodeError, ValueError) as error:
+        raise ValueError(f"Cannot read count bundle manifest: {manifest_path}") from error
+    required_top_level = {
+        "schema_version",
+        "created_at_utc",
+        "software",
+        "analysis_unit",
+        "statistical_grouping",
+        "configuration",
+        "inputs",
+        "outputs",
+    }
+    if set(manifest) != required_top_level:
+        raise ValueError("Count bundle manifest has missing or unknown top-level fields")
+    if manifest.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError(f"Unsupported count bundle schema: {manifest.get('schema_version')!r}")
+    if manifest.get("analysis_unit") not in {"snv", "feature"}:
+        raise ValueError("Count bundle has an invalid analysis_unit")
+
+    outputs = manifest.get("outputs")
+    if not isinstance(outputs, dict) or set(outputs) != {"counts", "donors"}:
+        raise ValueError("Count bundle must declare exactly counts and donors outputs")
+    resolved: dict[str, Path] = {}
+    for name, record in outputs.items():
+        if not isinstance(record, dict):
+            raise ValueError(f"Invalid output record for {name}")
+        expected_name = "counts.tsv.gz" if name == "counts" else "donors.tsv"
+        path = _bundle_member(manifest_path.parent, record, expected_name)
+        expected_hash = _validate_hash(record.get("sha256"), name)
+        if path.stat().st_size != record.get("size_bytes") or _sha256(path) != expected_hash:
+            raise ValueError(f"Count bundle output failed verification: {name}")
+        resolved[name] = path
+
+    try:
+        counts = pl.read_csv(resolved["counts"], separator="\t")
+        donors = pl.read_csv(resolved["donors"], separator="\t")
+    except (OSError, pl.exceptions.PolarsError) as error:
+        raise ValueError("Count bundle tables cannot be fully parsed") from error
+    if not counts.columns or counts.columns[0] != "donor_id" or counts.is_empty():
+        raise ValueError("Locked counts must begin with a donor_id column")
+    if donors.columns != ["donor_id", "vcf_sample", "bam"] or donors.is_empty():
+        raise ValueError("Locked donors.tsv has an invalid schema")
+    if sum(donors.null_count().row(0)):
+        raise ValueError("Locked donors.tsv contains missing values")
+    for column in ["donor_id", "vcf_sample", "bam"]:
+        if donors.get_column(column).n_unique() != donors.height:
+            raise ValueError(f"Locked donors.tsv contains duplicate {column} values")
+    count_donors = set(counts.get_column("donor_id").unique().to_list())
+    donor_ids = set(donors.get_column("donor_id").to_list())
+    if count_donors != donor_ids:
+        raise ValueError("Locked count donor IDs do not match donors.tsv")
+    if outputs["counts"].get("rows") != counts.height:
+        raise ValueError("Locked count row total does not match the manifest")
+    if outputs["counts"].get("donors") != donors.height:
+        raise ValueError("Locked count donor total does not match donors.tsv")
+    if outputs["donors"].get("rows") != donors.height:
+        raise ValueError("Locked donor row total does not match the manifest")
+
+    donor_inputs = manifest.get("inputs", {}).get("donors")
+    if not isinstance(donor_inputs, list):
+        raise ValueError("Count bundle donor provenance is missing")
+    provenance_ids = [record.get("donor_id") for record in donor_inputs]
+    if provenance_ids != sorted(donor_ids):
+        raise ValueError("Count bundle donor provenance does not match donors.tsv")
+    return manifest
+
+
+def _fsync_file(path: Path) -> None:
+    with path.open("rb") as handle:
+        os.fsync(handle.fileno())
+
+
+def _fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _publish_bundle(staging: Path, destination: Path) -> None:
+    """Claim the destination and publish the manifest as the commit marker."""
+    destination.mkdir()
+    try:
+        for name in ["counts.tsv.gz", "donors.tsv", "count_manifest.json"]:
+            os.replace(staging / name, destination / name)
+        _fsync_directory(destination)
+        staging.rmdir()
+    except BaseException:
+        shutil.rmtree(destination, ignore_errors=True)
+        raise
+
+
+def run_count_cohort(
+    donor_manifest: str,
+    variant_file: str,
+    output_dir: str,
+    *,
+    unit: AnalysisUnit | Literal["peak"],
+    region_file: str | None = None,
+    use_region_names: bool = True,
+) -> dict[str, str | int]:
+    """Count one final BAM per donor and publish a locked cohort bundle."""
+    normalized_unit: AnalysisUnit = "feature" if unit == "peak" else unit
+    if normalized_unit not in {"snv", "feature"}:
+        raise ValueError(f"Unknown analysis unit: {unit}")
+
+    manifest_path = Path(donor_manifest).expanduser().resolve(strict=True)
+    variants = Path(variant_file).expanduser().resolve(strict=True)
+    variants_index = _variant_index(variants)
+    regions = Path(region_file).expanduser().resolve(strict=True) if region_file else None
+    if normalized_unit == "feature" and regions is None:
+        raise ValueError("Feature counting requires --regions")
+
+    destination = Path(os.path.abspath(Path(output_dir).expanduser()))
+    if os.path.lexists(destination):
+        raise FileExistsError(f"Refusing to overwrite locked output directory: {destination}")
+    if not destination.parent.is_dir():
+        raise ValueError(f"Output parent directory does not exist: {destination.parent}")
+
+    donors = _read_donor_manifest(manifest_path, _vcf_samples(variants))
+    source_paths = [manifest_path, variants, variants_index]
+    if regions is not None:
+        source_paths.append(regions)
+    source_paths.extend(path for donor in donors for path in [donor.bam, donor.bam_index])
+
+    records: dict[Path, dict[str, str | int]] = {}
+    signatures: dict[Path, tuple[int, int, int, int]] = {}
+    for path in source_paths:
+        record, signature = _file_record(path)
+        records[path] = record
+        signatures[path] = signature
+
+    staging = Path(tempfile.mkdtemp(prefix=f".{destination.name}.staging-", dir=destination.parent))
+    work = staging / "_work"
+    work.mkdir()
+    try:
+        normalized_donors = pl.DataFrame(
+            {
+                "donor_id": [donor.donor_id for donor in donors],
+                "vcf_sample": [donor.vcf_sample for donor in donors],
+                "bam": [str(donor.bam) for donor in donors],
+            }
+        )
+        donors_path = staging / "donors.tsv"
+        normalized_donors.write_csv(donors_path, separator="\t")
+
+        donor_records: list[dict[str, Any]] = []
+        counts_path = staging / "counts.tsv.gz"
+        output_schema: pl.Schema | None = None
+        total_rows = 0
+        with counts_path.open("wb") as raw:
+            with gzip.GzipFile(filename="", mode="wb", fileobj=raw, mtime=0) as compressed:
+                for donor_index, donor in enumerate(donors):
+                    donor_dir = work / donor.donor_id
+                    donor_dir.mkdir()
+                    donor_counts = donor_dir / "counts.tsv"
+                    run_count_variants(
+                        bam_file=str(donor.bam),
+                        variant_file=str(variants),
+                        region_file=str(regions) if regions else None,
+                        samples=[donor.vcf_sample],
+                        use_region_names=use_region_names,
+                        out_file=str(donor_counts),
+                        temp_loc=str(donor_dir),
+                        include_indels=False,
+                        biallelic_only=True,
+                        use_rust=True,
+                    )
+                    _require_unchanged(donor.bam, signatures[donor.bam])
+                    _require_unchanged(donor.bam_index, signatures[donor.bam_index])
+
+                    frame = pl.read_csv(donor_counts, separator="\t")
+                    if frame.is_empty():
+                        raise RuntimeError(
+                            f"Allele counting produced no rows for donor {donor.donor_id}"
+                        )
+                    if normalized_unit == "snv":
+                        frame = _normalize_snv_rows(frame, donor.donor_id)
+                    else:
+                        frame = _normalize_feature_rows(frame, donor.donor_id)
+                    if output_schema is None:
+                        output_schema = frame.schema
+                    elif frame.schema != output_schema:
+                        raise RuntimeError(
+                            f"Count schema for {donor.donor_id} differs from prior donors"
+                        )
+                    frame.write_csv(
+                        compressed,
+                        include_header=donor_index == 0,
+                        separator="\t",
+                    )
+                    total_rows += frame.height
+                    donor_records.append(
+                        {
+                            "donor_id": donor.donor_id,
+                            "vcf_sample": donor.vcf_sample,
+                            "bam": records[donor.bam],
+                            "bam_index": records[donor.bam_index],
+                            "count_rows": frame.height,
+                        }
+                    )
+
+        for path, signature in signatures.items():
+            _require_unchanged(path, signature)
+            expected_hash = records[path]["sha256"]
+            if not isinstance(expected_hash, str):
+                raise RuntimeError(f"Missing locked input hash for {path}")
+            _require_matching_hash(path, expected_hash)
+
+        counts_record, _ = _file_record(counts_path)
+        donors_record, _ = _file_record(donors_path)
+        counts_record["path"] = "counts.tsv.gz"
+        donors_record["path"] = "donors.tsv"
+        input_records: dict[str, Any] = {
+            "donor_manifest": records[manifest_path],
+            "variants": records[variants],
+            "variants_index": records[variants_index],
+            "donors": donor_records,
+        }
+        if regions is not None:
+            input_records["regions"] = records[regions]
+        manifest = {
+            "schema_version": SCHEMA_VERSION,
+            "created_at_utc": datetime.now(UTC).isoformat(),
+            "software": {
+                "package": "wasp2",
+                "version": _package_version(),
+                **_git_state(),
+            },
+            "analysis_unit": normalized_unit,
+            "statistical_grouping": (
+                "donor-plus-variant" if normalized_unit == "snv" else "donor-plus-feature"
+            ),
+            "configuration": {
+                "one_final_bam_per_donor": True,
+                "biallelic_snv_only": True,
+                "include_indels": False,
+                "use_region_names": use_region_names,
+            },
+            "inputs": input_records,
+            "outputs": {
+                "counts": {
+                    **counts_record,
+                    "rows": total_rows,
+                    "donors": len(donors),
+                },
+                "donors": {
+                    **donors_record,
+                    "rows": len(donors),
+                },
+            },
+        }
+        manifest_path_out = staging / "count_manifest.json"
+        manifest_path_out.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+        for path in [counts_path, donors_path, manifest_path_out]:
+            _fsync_file(path)
+        _fsync_directory(staging)
+        verify_count_bundle(manifest_path_out)
+
+        shutil.rmtree(work)
+        _publish_bundle(staging, destination)
+        return {
+            "output_dir": str(destination),
+            "counts": str(destination / "counts.tsv.gz"),
+            "donor_manifest": str(destination / "donors.tsv"),
+            "manifest": str(destination / "count_manifest.json"),
+            "donors": len(donors),
+            "rows": total_rows,
+        }
+    except BaseException:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise

--- a/tests/counting/test_count_alleles.py
+++ b/tests/counting/test_count_alleles.py
@@ -1,0 +1,46 @@
+import polars as pl
+import pytest
+
+from counting import count_alleles
+
+
+def _variants() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "chrom": ["chr1"],
+            "pos": [10],
+            "ref": ["A"],
+            "alt": ["G"],
+        }
+    ).with_columns(pl.col("chrom").cast(pl.Categorical))
+
+
+@pytest.mark.unit
+def test_bulk_counting_fails_closed_on_chromosome_error(monkeypatch):
+    monkeypatch.setattr(count_alleles, "RUST_AVAILABLE", True)
+
+    def fail(*args, **kwargs):
+        raise RuntimeError("counter failed")
+
+    monkeypatch.setattr(count_alleles, "count_snp_alleles_rust", fail)
+    with pytest.raises(RuntimeError, match="counter failed"):
+        count_alleles.make_count_df("sample.bam", _variants())
+
+
+@pytest.mark.unit
+def test_bulk_counting_preserves_counts_above_uint16(monkeypatch):
+    monkeypatch.setattr(count_alleles, "RUST_AVAILABLE", True)
+    monkeypatch.setattr(
+        count_alleles,
+        "count_snp_alleles_rust",
+        lambda *args, **kwargs: [("chr1", 10, 70_000, 80_000, 90_000)],
+    )
+    result = count_alleles.make_count_df("sample.bam", _variants())
+    assert result.select("ref_count", "alt_count", "other_count").row(0) == (
+        70_000,
+        80_000,
+        90_000,
+    )
+    assert result.schema["ref_count"] == pl.UInt32
+    assert result.schema["alt_count"] == pl.UInt32
+    assert result.schema["other_count"] == pl.UInt32

--- a/tests/counting/test_count_cohort.py
+++ b/tests/counting/test_count_cohort.py
@@ -1,0 +1,344 @@
+import hashlib
+import json
+import os
+from pathlib import Path
+
+import polars as pl
+import pysam
+import pytest
+from typer.testing import CliRunner
+
+from counting import count_alleles
+from counting import run_counting_cohort as cohort
+from counting.__main__ import app
+
+SHARED_DATA = Path(__file__).parents[1] / "shared_data"
+
+
+def _indexed_vcf(tmp_path: Path) -> Path:
+    source = tmp_path / "variants.vcf"
+    source.write_text(
+        "##fileformat=VCFv4.2\n"
+        "##contig=<ID=chr1,length=1000>\n"
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n'
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tvcf_a\tvcf_b\n"
+        "chr1\t10\t.\tA\tG\t.\tPASS\t.\tGT\t0|1\t1|0\n"
+    )
+    compressed = tmp_path / "variants.vcf.gz"
+    pysam.tabix_compress(str(source), str(compressed), force=True)
+    pysam.tabix_index(str(compressed), preset="vcf", force=True)
+    return compressed
+
+
+def _inputs(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
+    variants = _indexed_vcf(tmp_path)
+    regions = tmp_path / "peaks.bed"
+    regions.write_text("chr1\t0\t100\tpeak1\n")
+    rows = []
+    for donor_id, vcf_sample in [("donor_b", "vcf_b"), ("donor_a", "vcf_a")]:
+        bam = tmp_path / f"{donor_id}.bam"
+        header = {"HD": {"VN": "1.6", "SO": "coordinate"}, "SQ": [{"SN": "chr1", "LN": 1000}]}
+        with pysam.AlignmentFile(str(bam), "wb", header=header) as alignment:
+            read = pysam.AlignedSegment()
+            read.query_name = donor_id
+            read.query_sequence = "AAAAAAAAAA"
+            read.flag = 0
+            read.reference_id = 0
+            read.reference_start = 9
+            read.mapping_quality = 60
+            read.cigar = ((0, 10),)
+            read.query_qualities = pysam.qualitystring_to_array("FFFFFFFFFF")
+            alignment.write(read)
+        pysam.index(str(bam))
+        rows.append(f"{donor_id}\t{vcf_sample}\t{bam.name}\n")
+    manifest = tmp_path / "donors.input.tsv"
+    manifest.write_text("donor_id\tvcf_sample\tbam\n" + "".join(rows))
+    return manifest, variants, regions, tmp_path / "locked_counts"
+
+
+def _fake_count(**kwargs) -> None:
+    frame = pl.DataFrame(
+        {
+            "chrom": ["chr1", "chr1"],
+            "pos0": [9, 9],
+            "pos": [10, 10],
+            "ref": ["A", "A"],
+            "alt": ["G", "G"],
+            "GT": ["0|1", "0|1"],
+            "region": ["peak1", "peak_overlap"],
+            "ref_count": [8, 8],
+            "alt_count": [4, 4],
+            "other_count": [0, 0],
+        }
+    )
+    frame.write_csv(kwargs["out_file"], separator="\t")
+
+
+@pytest.mark.unit
+def test_snv_bundle_locks_explicit_donor_mapping(tmp_path, monkeypatch):
+    manifest, variants, regions, output = _inputs(tmp_path)
+    calls = []
+
+    def record_count(**kwargs) -> None:
+        calls.append(kwargs)
+        _fake_count(**kwargs)
+
+    monkeypatch.setattr(cohort, "run_count_variants", record_count)
+    result = cohort.run_count_cohort(
+        str(manifest),
+        str(variants),
+        str(output),
+        unit="snv",
+        region_file=str(regions),
+    )
+
+    counts = pl.read_csv(result["counts"], separator="\t")
+    assert counts.height == 2
+    assert counts.columns[0] == "donor_id"
+    assert counts.get_column("donor_id").to_list() == ["donor_a", "donor_b"]
+    assert "region" not in counts.columns
+    assert [call["samples"] for call in calls] == [["vcf_a"], ["vcf_b"]]
+
+    donors = pl.read_csv(result["donor_manifest"], separator="\t")
+    assert donors.columns == ["donor_id", "vcf_sample", "bam"]
+    assert donors.get_column("donor_id").to_list() == ["donor_a", "donor_b"]
+
+    locked = cohort.verify_count_bundle(result["manifest"])
+    assert locked["schema_version"] == cohort.SCHEMA_VERSION
+    assert locked["analysis_unit"] == "snv"
+    assert locked["statistical_grouping"] == "donor-plus-variant"
+    assert locked["configuration"]["biallelic_snv_only"] is True
+    assert locked["configuration"]["include_indels"] is False
+    assert locked["outputs"]["counts"]["sha256"]
+    assert locked["inputs"]["variants_index"]["sha256"]
+    assert locked["inputs"]["donors"][0]["bam_index"]["sha256"]
+    assert sorted(path.name for path in output.iterdir()) == [
+        "count_manifest.json",
+        "counts.tsv.gz",
+        "donors.tsv",
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("unit", ["feature", "peak"])
+def test_feature_bundle_preserves_feature_rows_and_peak_alias(tmp_path, monkeypatch, unit):
+    manifest, variants, regions, output = _inputs(tmp_path)
+    monkeypatch.setattr(cohort, "run_count_variants", _fake_count)
+    result = cohort.run_count_cohort(
+        str(manifest),
+        str(variants),
+        str(output),
+        unit=unit,
+        region_file=str(regions),
+    )
+
+    counts = pl.read_csv(result["counts"], separator="\t")
+    assert counts.height == 4
+    assert counts.get_column("region").unique().sort().to_list() == ["peak1", "peak_overlap"]
+    locked = cohort.verify_count_bundle(result["manifest"])
+    assert locked["analysis_unit"] == "feature"
+    assert locked["statistical_grouping"] == "donor-plus-feature"
+
+
+@pytest.mark.unit
+def test_feature_bundle_requires_regions(tmp_path):
+    manifest, variants, _, output = _inputs(tmp_path)
+    with pytest.raises(ValueError, match="requires --regions"):
+        cohort.run_count_cohort(str(manifest), str(variants), str(output), unit="feature")
+
+
+@pytest.mark.unit
+def test_manifest_requires_explicit_unique_mapping(tmp_path):
+    manifest, variants, _, output = _inputs(tmp_path)
+    bam = tmp_path / "donor_a.bam"
+    manifest.write_text(
+        f"donor_id\tvcf_sample\tbam\ndonor_a\tvcf_a\t{bam}\ndonor_a\tvcf_b\t{bam}\n"
+    )
+    with pytest.raises(ValueError, match="Duplicate donor_id"):
+        cohort.run_count_cohort(str(manifest), str(variants), str(output), unit="snv")
+
+    manifest.write_text("donor_id\tvcf_sample\tbam\ndonor_a\tnot_in_vcf\tdonor_a.bam\n")
+    with pytest.raises(ValueError, match="VCF sample not found"):
+        cohort.run_count_cohort(str(manifest), str(variants), str(output), unit="snv")
+
+
+@pytest.mark.unit
+def test_bundle_verifier_rejects_tampering(tmp_path, monkeypatch):
+    manifest, variants, _, output = _inputs(tmp_path)
+    monkeypatch.setattr(cohort, "run_count_variants", _fake_count)
+    result = cohort.run_count_cohort(str(manifest), str(variants), str(output), unit="snv")
+    Path(result["counts"]).write_bytes(Path(result["counts"]).read_bytes() + b"tampered")
+    with pytest.raises(ValueError, match="failed verification: counts"):
+        cohort.verify_count_bundle(result["manifest"])
+
+
+@pytest.mark.unit
+def test_failure_removes_staging_and_detects_input_mutation(tmp_path, monkeypatch):
+    manifest, variants, _, output = _inputs(tmp_path)
+
+    def mutate_input(**kwargs) -> None:
+        Path(kwargs["bam_file"]).write_bytes(b"changed")
+        _fake_count(**kwargs)
+
+    monkeypatch.setattr(cohort, "run_count_variants", mutate_input)
+    with pytest.raises(RuntimeError, match="Input changed"):
+        cohort.run_count_cohort(str(manifest), str(variants), str(output), unit="snv")
+    assert not output.exists()
+    assert not list(tmp_path.glob(".locked_counts.staging-*"))
+
+
+@pytest.mark.unit
+def test_cli_routes_locked_contract(monkeypatch):
+    captured = {}
+
+    def fake_run(**kwargs):
+        captured.update(kwargs)
+        return {"donors": 2, "rows": 4, "output_dir": "/tmp/out"}
+
+    monkeypatch.setattr("counting.__main__.run_count_cohort", fake_run)
+    result = CliRunner().invoke(
+        app,
+        [
+            "count-cohort",
+            "donors.tsv",
+            "variants.vcf.gz",
+            "counts",
+            "--unit",
+            "peak",
+            "--regions",
+            "peaks.bed",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["unit"] == "peak"
+    assert captured["region_file"] == "peaks.bed"
+
+
+@pytest.mark.unit
+def test_bundle_refuses_overwrite(tmp_path, monkeypatch):
+    manifest, variants, _, output = _inputs(tmp_path)
+    monkeypatch.setattr(cohort, "run_count_variants", _fake_count)
+    output.mkdir()
+    with pytest.raises(FileExistsError, match="Refusing to overwrite"):
+        cohort.run_count_cohort(str(manifest), str(variants), str(output), unit="snv")
+
+
+@pytest.mark.unit
+def test_manifest_json_uses_relative_bundle_members(tmp_path, monkeypatch):
+    manifest, variants, _, output = _inputs(tmp_path)
+    monkeypatch.setattr(cohort, "run_count_variants", _fake_count)
+    result = cohort.run_count_cohort(str(manifest), str(variants), str(output), unit="snv")
+    locked = json.loads(Path(result["manifest"]).read_text())
+    assert locked["outputs"]["counts"]["path"] == "counts.tsv.gz"
+    assert locked["outputs"]["donors"]["path"] == "donors.tsv"
+
+
+@pytest.mark.unit
+def test_expected_manifest_digest_is_an_external_trust_anchor(tmp_path, monkeypatch):
+    manifest, variants, _, output = _inputs(tmp_path)
+    monkeypatch.setattr(cohort, "run_count_variants", _fake_count)
+    result = cohort.run_count_cohort(str(manifest), str(variants), str(output), unit="snv")
+    digest = hashlib.sha256(Path(result["manifest"]).read_bytes()).hexdigest()
+    cohort.verify_count_bundle(result["manifest"], expected_manifest_sha256=digest)
+    with pytest.raises(ValueError, match="failed expected SHA-256"):
+        cohort.verify_count_bundle(result["manifest"], expected_manifest_sha256="0" * 64)
+
+
+@pytest.mark.unit
+def test_same_size_input_mutation_with_restored_mtime_is_detected(tmp_path, monkeypatch):
+    manifest, variants, _, output = _inputs(tmp_path)
+    target = tmp_path / "donor_a.bam"
+
+    def mutate_without_stat_change(**kwargs) -> None:
+        if Path(kwargs["bam_file"]) == target:
+            stat = target.stat()
+            content = bytearray(target.read_bytes())
+            content[-1] ^= 1
+            target.write_bytes(content)
+            os.utime(target, ns=(stat.st_atime_ns, stat.st_mtime_ns))
+        _fake_count(**kwargs)
+
+    monkeypatch.setattr(cohort, "run_count_variants", mutate_without_stat_change)
+    with pytest.raises(RuntimeError, match="Input content changed"):
+        cohort.run_count_cohort(str(manifest), str(variants), str(output), unit="snv")
+    assert not output.exists()
+
+
+@pytest.mark.unit
+def test_atomic_destination_claim_never_replaces_racing_directory(tmp_path, monkeypatch):
+    manifest, variants, _, output = _inputs(tmp_path)
+    calls = 0
+
+    def create_destination_during_count(**kwargs) -> None:
+        nonlocal calls
+        calls += 1
+        _fake_count(**kwargs)
+        if calls == 2:
+            output.mkdir()
+
+    monkeypatch.setattr(cohort, "run_count_variants", create_destination_during_count)
+    with pytest.raises(FileExistsError):
+        cohort.run_count_cohort(str(manifest), str(variants), str(output), unit="snv")
+    assert output.is_dir()
+    assert not list(tmp_path.glob(".locked_counts.staging-*"))
+
+
+@pytest.mark.unit
+def test_broken_symlink_destination_is_treated_as_existing(tmp_path):
+    manifest, variants, _, output = _inputs(tmp_path)
+    output.symlink_to(tmp_path / "missing-target")
+    with pytest.raises(FileExistsError, match="Refusing to overwrite"):
+        cohort.run_count_cohort(str(manifest), str(variants), str(output), unit="snv")
+
+
+@pytest.mark.unit
+def test_count_outputs_are_byte_deterministic(tmp_path, monkeypatch):
+    manifest, variants, _, first = _inputs(tmp_path)
+    second = tmp_path / "locked_counts_second"
+    monkeypatch.setattr(cohort, "run_count_variants", _fake_count)
+    first_result = cohort.run_count_cohort(str(manifest), str(variants), str(first), unit="snv")
+    second_result = cohort.run_count_cohort(str(manifest), str(variants), str(second), unit="snv")
+    assert Path(first_result["counts"]).read_bytes() == Path(second_result["counts"]).read_bytes()
+    assert (
+        Path(first_result["donor_manifest"]).read_bytes()
+        == Path(second_result["donor_manifest"]).read_bytes()
+    )
+
+
+@pytest.mark.unit
+def test_verifier_rejects_noncanonical_output_paths(tmp_path, monkeypatch):
+    manifest, variants, _, output = _inputs(tmp_path)
+    monkeypatch.setattr(cohort, "run_count_variants", _fake_count)
+    result = cohort.run_count_cohort(str(manifest), str(variants), str(output), unit="snv")
+    manifest_path = Path(result["manifest"])
+    locked = json.loads(manifest_path.read_text())
+    locked["outputs"]["counts"]["path"] = "./counts.tsv.gz"
+    manifest_path.write_text(json.dumps(locked, indent=2, sort_keys=True) + "\n")
+    with pytest.raises(ValueError, match="must be counts.tsv.gz"):
+        cohort.verify_count_bundle(manifest_path)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("unit", ["snv", "feature"])
+def test_real_counting_pipeline_publishes_verified_bundle(tmp_path, unit):
+    if not count_alleles.RUST_AVAILABLE:
+        pytest.skip("Rust counting extension is not installed")
+    donor_manifest = tmp_path / "donors.tsv"
+    donor_manifest.write_text(
+        "donor_id\tvcf_sample\tbam\n"
+        f"donor_b\tsample2\t{SHARED_DATA / 'sample2.bam'}\n"
+        f"donor_a\tsample1\t{SHARED_DATA / 'sample1.bam'}\n"
+    )
+    output = tmp_path / f"real_{unit}_counts"
+    result = cohort.run_count_cohort(
+        str(donor_manifest),
+        str(SHARED_DATA / "variants.vcf.gz"),
+        str(output),
+        unit=unit,
+        region_file=str(SHARED_DATA / "regions.bed"),
+    )
+    locked = cohort.verify_count_bundle(result["manifest"])
+    counts = pl.read_csv(result["counts"], separator="\t")
+    assert counts.get_column("donor_id").unique().sort().to_list() == ["donor_a", "donor_b"]
+    assert locked["outputs"]["counts"]["rows"] == counts.height
+    assert ("region" in counts.columns) is (unit == "feature")


### PR DESCRIPTION
## Summary

- add `wasp2-count count-cohort` with explicit `donor_id` / `vcf_sample` / BAM mapping
- publish verified `counts.tsv.gz`, `donors.tsv`, and `count_manifest.json` bundles without overwriting existing outputs
- fail closed on chromosome counting errors and use UInt32 bulk count columns
- add real two-donor SNV and feature integration coverage plus wheel-install smoke checks

## Contract

- one final indexed BAM per donor
- indexed shared VCF/BCF containing every VCF sample
- biallelic SNV selection is recorded in the manifest
- `donor_id` is retained on every count row
- input and output SHA-256 provenance; manifest can be verified against an external expected digest
- atomic destination claim; manifest is published last as the commit marker

## Validation

- 18 focused unit tests passed
- 2 real BAM/VCF integration tests passed for SNV and feature modes
- Ruff format/check and YAML parsing passed
- broader local suite: 166 passed, 18 skipped; two analysis tests were incompatible with the temporary later-prototype Rust binary used locally, so exact-branch Rust build remains covered by PR CI
- Sphinx rendered all pages; strict local mode only reported pre-existing intersphinx network and unrelated docstring warnings

This PR intentionally contains no donor-aware statistical inference. That is a separate follow-up based on the merged `dev`.
