### PR TITLE
Prepare WASP2 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,50 @@ All notable changes to WASP2 will be documented in this file.
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-07-14
+
 ### Added
 - `wasp2-count count-cohort` for one-final-BAM-per-donor bulk counting with explicit
-  `donor_id`/`vcf_sample` mapping, atomic locked outputs, and SHA-256 provenance.
-- `--per-variant` / `--snv-solo` flag for `wasp2 analysis find_imbalance` to test each SNV
-  independently instead of grouping by a region column (forces per-variant even when a region
-  column is present; mutually exclusive with `--region_col`).
+  `donor_id`/`vcf_sample` mapping, atomic locked outputs, and SHA-256 provenance manifests.
+- Linear-dispersion and donor-specific-dispersion beta-binomial implementations in the Rust
+  analysis API, including phased feature-level inference.
+- `--per-variant` / `--snv-solo` for independent SNV tests and explicit `--region_col` support
+  for feature- or peak-level aggregation.
+- A Rust single-cell ATAC allele counter with chromosome-parallel execution and Python fallback.
 
 ### Changed
-- Bulk counting now fails closed on chromosome-level Rust errors and stores allele counts as
-  `UInt32` to avoid truncating depths above 65,535.
-- `--phased` and `--region_col` are now forwarded to the Rust analysis backend (previously parsed
-  but dropped, so the Rust path always ran unphased / feature-grouped).
-- `--groupby` now raises a clear error on the Rust analysis backend instead of being silently
-  ignored — it only re-keys the grouping column, so use `--region_col <parent_column>` for
-  parent-level grouping (identical result).
+- VCF conversion now selects biallelic SNVs by default; multi-allelic records require the
+  explicit `--include-multiallelic` option.
+- Phased inference accepts only numeric VCF heterozygote orientation (`0|1` and `1|0`) for parity
+  with the archived Python implementation; allele-string genotypes do not imply cross-SNV phase.
+- `--phased` and `--region_col` are forwarded to the Rust backend; unsupported `--groupby`
+  requests fail closed and direct users to `--region_col <parent_column>`.
+- Single-cell AnnData output now follows the scverse `obs=cells`, `var=variants` orientation.
+- Packaging derives the Python version from installed metadata and synchronizes Cargo, pixi,
+  containers, Galaxy, Nextflow, documentation, and citation metadata from one release command.
+- The release workflow now builds and tests 16 wheels, a source distribution, multi-architecture
+  containers, and a Singularity image before publishing, with checksums, SBOMs, and provenance.
+
+### Fixed
+- Unphased multi-SNV likelihoods now use log-space dynamic programming to prevent underflow.
+- Linear inference uses per-SNV dispersion throughout the alternative optimization, phased
+  donor-specific inference uses each observation's donor dispersion, and LRTs are non-negative.
+- Bulk counts use `UInt32`, and single-cell pseudobulk/observation sums widen safely instead of
+  overflowing at 65,535; single-cell counting also works without an optional feature file.
+- Count-analysis TSV parsing is header-driven, so `pos0`, `GT`, sample, and donor metadata cannot
+  be mistaken for feature grouping columns.
+- Galaxy wrappers now match current CLI inputs and outputs, use datasets instead of job-local JSON
+  paths between jobs, and run all four functional tests successfully.
+- BAM merging uses portable `samtools merge` positional output syntax supported by older samtools.
+
+### Security
+- GitHub Actions are commit-pinned with read-only default tokens, dependency review, CodeQL,
+  Gitleaks, Bandit, pip-audit, cargo-audit, and strict aggregate release gates.
+- Release tags must be signed, annotated, version-matched, and point to an ancestor of `master`.
+
+### Removed
+- Stale duplicate in-repository Bioconda recipe files, internal automation templates, hardcoded lab
+  paths, and redundant documentation that conflicted with the maintained user guides.
 
 ## [1.4.1] - 2026-04-18
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ authors:
   - name: "McVicker Lab"
     affiliation: "Salk Institute for Biological Studies"
 
-version: "1.4.1"
-date-released: "2026-04-18"
+version: "1.5.0"
+date-released: "2026-07-14"
 license: MIT
 
 repository-code: "https://github.com/mcvickerlab/WASP2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ FROM python:3.11-slim-bookworm
 
 # Version: keep in sync with rust/Cargo.toml (single source of truth)
 # Run scripts/check-version-consistency.sh to verify
-ARG VERSION=1.4.1
+ARG VERSION=1.5.0
 
 LABEL org.opencontainers.image.source="https://github.com/mcvickerlab/WASP2"
 LABEL org.opencontainers.image.description="WASP2: Allele-specific analysis of NGS data with Rust acceleration"

--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ The PyPI package does not install external tools such as `samtools`,
 ### Docker
 
 ```bash
-docker pull ghcr.io/mcvickerlab/wasp2:1.4.1
-docker run --rm ghcr.io/mcvickerlab/wasp2:1.4.1 wasp2-count --help
+docker pull ghcr.io/mcvickerlab/wasp2:1.5.0
+docker run --rm ghcr.io/mcvickerlab/wasp2:1.5.0 wasp2-count --help
 ```
 
 ### Singularity/Apptainer
 
 ```bash
-singularity pull wasp2.sif docker://ghcr.io/mcvickerlab/wasp2:1.4.1
+singularity pull wasp2.sif docker://ghcr.io/mcvickerlab/wasp2:1.5.0
 singularity exec wasp2.sif wasp2-count --help
 ```
 

--- a/Singularity.def
+++ b/Singularity.def
@@ -8,11 +8,11 @@
 # Or pull directly: singularity pull docker://ghcr.io/mcvickerlab/wasp2:latest
 
 Bootstrap: docker
-From: ghcr.io/mcvickerlab/wasp2:1.4.1
+From: ghcr.io/mcvickerlab/wasp2:1.5.0
 
 %labels
     Author Jeff Jaureguy <jeffpjaureguy@gmail.com>
-    Version 1.4.1
+    Version 1.5.0
     Description WASP2: Allele-specific analysis of NGS data with Rust acceleration
 
 %help

--- a/docs/CONTAINER_USAGE.md
+++ b/docs/CONTAINER_USAGE.md
@@ -5,23 +5,23 @@
 The Docker image validated for this update is:
 
 ```bash
-ghcr.io/mcvickerlab/wasp2:1.4.1
+ghcr.io/mcvickerlab/wasp2:1.5.0
 ```
 
 Pull and inspect the available CLI tools:
 
 ```bash
-docker pull ghcr.io/mcvickerlab/wasp2:1.4.1
+docker pull ghcr.io/mcvickerlab/wasp2:1.5.0
 
-docker run --rm ghcr.io/mcvickerlab/wasp2:1.4.1 wasp2-count --help
-docker run --rm ghcr.io/mcvickerlab/wasp2:1.4.1 wasp2-map --help
-docker run --rm ghcr.io/mcvickerlab/wasp2:1.4.1 wasp2-analyze --help
+docker run --rm ghcr.io/mcvickerlab/wasp2:1.5.0 wasp2-count --help
+docker run --rm ghcr.io/mcvickerlab/wasp2:1.5.0 wasp2-map --help
+docker run --rm ghcr.io/mcvickerlab/wasp2:1.5.0 wasp2-analyze --help
 ```
 
 Mount local data when running workflows:
 
 ```bash
-docker run --rm -v "$PWD":/data ghcr.io/mcvickerlab/wasp2:1.4.1 \
+docker run --rm -v "$PWD":/data ghcr.io/mcvickerlab/wasp2:1.5.0 \
   wasp2-count count-variants /data/sample.bam /data/variants.vcf.gz -o /data/counts.tsv
 ```
 
@@ -30,14 +30,14 @@ docker run --rm -v "$PWD":/data ghcr.io/mcvickerlab/wasp2:1.4.1 \
 For HPC environments using SIF images:
 
 ```bash
-singularity pull wasp2.sif docker://ghcr.io/mcvickerlab/wasp2:1.4.1
+singularity pull wasp2.sif docker://ghcr.io/mcvickerlab/wasp2:1.5.0
 singularity exec wasp2.sif wasp2-count --help
 ```
 
 or:
 
 ```bash
-apptainer pull wasp2.sif docker://ghcr.io/mcvickerlab/wasp2:1.4.1
+apptainer pull wasp2.sif docker://ghcr.io/mcvickerlab/wasp2:1.5.0
 apptainer exec wasp2.sif wasp2-count --help
 ```
 
@@ -48,7 +48,7 @@ installed locally.
 ## Mapping Example
 
 ```bash
-docker run --rm -v "$PWD":/data ghcr.io/mcvickerlab/wasp2:1.4.1 \
+docker run --rm -v "$PWD":/data ghcr.io/mcvickerlab/wasp2:1.5.0 \
   wasp2-map make-reads /data/sample.bam /data/variants.vcf.gz \
   --samples sample1 \
   --out_dir /data/remap_dir
@@ -57,7 +57,7 @@ docker run --rm -v "$PWD":/data ghcr.io/mcvickerlab/wasp2:1.4.1 \
 After realigning the swapped FASTQ reads with your aligner of choice:
 
 ```bash
-docker run --rm -v "$PWD":/data ghcr.io/mcvickerlab/wasp2:1.4.1 \
+docker run --rm -v "$PWD":/data ghcr.io/mcvickerlab/wasp2:1.5.0 \
   wasp2-map filter-remapped /data/remapped.bam \
   --wasp_data_json /data/remap_dir/sample_wasp_data_files.json \
   --out_bam /data/filtered.bam
@@ -66,7 +66,7 @@ docker run --rm -v "$PWD":/data ghcr.io/mcvickerlab/wasp2:1.4.1 \
 ## Counting Example
 
 ```bash
-docker run --rm -v "$PWD":/data ghcr.io/mcvickerlab/wasp2:1.4.1 \
+docker run --rm -v "$PWD":/data ghcr.io/mcvickerlab/wasp2:1.5.0 \
   wasp2-count count-variants /data/filtered.bam /data/variants.vcf.gz \
   --samples sample1 \
   --region /data/genes.gtf \

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -31,11 +31,11 @@ this environment.
 
 .. code-block:: bash
 
-   docker pull ghcr.io/mcvickerlab/wasp2:1.4.1
+   docker pull ghcr.io/mcvickerlab/wasp2:1.5.0
 
-   docker run --rm ghcr.io/mcvickerlab/wasp2:1.4.1 wasp2-count --help
-   docker run --rm ghcr.io/mcvickerlab/wasp2:1.4.1 wasp2-map --help
-   docker run --rm ghcr.io/mcvickerlab/wasp2:1.4.1 wasp2-analyze --help
+   docker run --rm ghcr.io/mcvickerlab/wasp2:1.5.0 wasp2-count --help
+   docker run --rm ghcr.io/mcvickerlab/wasp2:1.5.0 wasp2-map --help
+   docker run --rm ghcr.io/mcvickerlab/wasp2:1.5.0 wasp2-analyze --help
 
 Via Singularity/Apptainer
 -------------------------
@@ -44,14 +44,14 @@ For HPC environments that require SIF images:
 
 .. code-block:: bash
 
-   singularity pull wasp2.sif docker://ghcr.io/mcvickerlab/wasp2:1.4.1
+   singularity pull wasp2.sif docker://ghcr.io/mcvickerlab/wasp2:1.5.0
    singularity exec wasp2.sif wasp2-count --help
 
 or with Apptainer:
 
 .. code-block:: bash
 
-   apptainer pull wasp2.sif docker://ghcr.io/mcvickerlab/wasp2:1.4.1
+   apptainer pull wasp2.sif docker://ghcr.io/mcvickerlab/wasp2:1.5.0
    apptainer exec wasp2.sif wasp2-count --help
 
 .. note::

--- a/galaxy/tools/wasp2/macros.xml
+++ b/galaxy/tools/wasp2/macros.xml
@@ -2,7 +2,7 @@
     <!-- WASP2 Galaxy Tool Macros -->
     <!-- Shared definitions for all WASP2 tools -->
 
-    <token name="@TOOL_VERSION@">1.4.1</token>
+    <token name="@TOOL_VERSION@">1.5.0</token>
     <token name="@VERSION_SUFFIX@">+galaxy0</token>
     <token name="@PROFILE@">23.0</token>
 

--- a/pipelines/nf-atacseq/conf/test_stub.config
+++ b/pipelines/nf-atacseq/conf/test_stub.config
@@ -34,6 +34,6 @@ params {
 // Override ALL process containers for stub testing (only needs bash)
 process {
     withName: '.*' {
-        container = 'ghcr.io/mcvickerlab/wasp2:1.4.1'
+        container = 'ghcr.io/mcvickerlab/wasp2:1.5.0'
     }
 }

--- a/pipelines/nf-atacseq/modules/local/wasp2_count_variants.nf
+++ b/pipelines/nf-atacseq/modules/local/wasp2_count_variants.nf
@@ -4,8 +4,8 @@ process WASP2_COUNT_VARIANTS {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/mcvickerlab/wasp2:1.4.1' :
-        'ghcr.io/mcvickerlab/wasp2:1.4.1' }"
+        'docker://ghcr.io/mcvickerlab/wasp2:1.5.0' :
+        'ghcr.io/mcvickerlab/wasp2:1.5.0' }"
 
     input:
     tuple val(meta), path(bam), path(bai)
@@ -46,7 +46,7 @@ process WASP2_COUNT_VARIANTS {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        wasp2: 1.4.1
+        wasp2: 1.5.0
     END_VERSIONS
     """
 }

--- a/pipelines/nf-atacseq/modules/local/wasp2_count_variants/environment.yml
+++ b/pipelines/nf-atacseq/modules/local/wasp2_count_variants/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::wasp2=1.4.1
+  - bioconda::wasp2=1.5.0

--- a/pipelines/nf-atacseq/modules/local/wasp2_count_variants/main.nf
+++ b/pipelines/nf-atacseq/modules/local/wasp2_count_variants/main.nf
@@ -4,8 +4,8 @@ process WASP2_COUNT_VARIANTS {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/mcvickerlab/wasp2:1.4.1' :
-        'ghcr.io/mcvickerlab/wasp2:1.4.1' }"
+        'docker://ghcr.io/mcvickerlab/wasp2:1.5.0' :
+        'ghcr.io/mcvickerlab/wasp2:1.5.0' }"
 
     input:
     tuple val(meta), path(bam), path(bai)
@@ -46,7 +46,7 @@ process WASP2_COUNT_VARIANTS {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        wasp2: 1.4.1
+        wasp2: 1.5.0
     END_VERSIONS
     """
 }

--- a/pipelines/nf-atacseq/modules/local/wasp2_filter_remapped.nf
+++ b/pipelines/nf-atacseq/modules/local/wasp2_filter_remapped.nf
@@ -4,8 +4,8 @@ process WASP2_FILTER_REMAPPED {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/mcvickerlab/wasp2:1.4.1' :
-        'ghcr.io/mcvickerlab/wasp2:1.4.1' }"
+        'docker://ghcr.io/mcvickerlab/wasp2:1.5.0' :
+        'ghcr.io/mcvickerlab/wasp2:1.5.0' }"
 
     input:
     tuple val(meta), path(remapped_bam), path(remapped_bai), path(to_remap_bam), path(keep_bam), path(wasp_json)
@@ -52,7 +52,7 @@ process WASP2_FILTER_REMAPPED {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        wasp2: 1.4.1
+        wasp2: 1.5.0
         samtools: 1.17
     END_VERSIONS
     """

--- a/pipelines/nf-atacseq/modules/local/wasp2_filter_remapped/environment.yml
+++ b/pipelines/nf-atacseq/modules/local/wasp2_filter_remapped/environment.yml
@@ -4,5 +4,5 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::wasp2=1.4.1
+  - bioconda::wasp2=1.5.0
   - bioconda::samtools=1.17

--- a/pipelines/nf-atacseq/modules/local/wasp2_filter_remapped/main.nf
+++ b/pipelines/nf-atacseq/modules/local/wasp2_filter_remapped/main.nf
@@ -4,8 +4,8 @@ process WASP2_FILTER_REMAPPED {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/mcvickerlab/wasp2:1.4.1' :
-        'ghcr.io/mcvickerlab/wasp2:1.4.1' }"
+        'docker://ghcr.io/mcvickerlab/wasp2:1.5.0' :
+        'ghcr.io/mcvickerlab/wasp2:1.5.0' }"
 
     input:
     tuple val(meta), path(remapped_bam), path(remapped_bai), path(to_remap_bam), path(keep_bam), path(wasp_json)
@@ -52,7 +52,7 @@ process WASP2_FILTER_REMAPPED {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        wasp2: 1.4.1
+        wasp2: 1.5.0
         samtools: 1.17
     END_VERSIONS
     """

--- a/pipelines/nf-atacseq/modules/local/wasp2_find_imbalance.nf
+++ b/pipelines/nf-atacseq/modules/local/wasp2_find_imbalance.nf
@@ -4,8 +4,8 @@ process WASP2_FIND_IMBALANCE {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/mcvickerlab/wasp2:1.4.1' :
-        'ghcr.io/mcvickerlab/wasp2:1.4.1' }"
+        'docker://ghcr.io/mcvickerlab/wasp2:1.5.0' :
+        'ghcr.io/mcvickerlab/wasp2:1.5.0' }"
 
     input:
     tuple val(meta), path(counts)
@@ -44,7 +44,7 @@ process WASP2_FIND_IMBALANCE {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        wasp2: 1.4.1
+        wasp2: 1.5.0
     END_VERSIONS
     """
 }

--- a/pipelines/nf-atacseq/modules/local/wasp2_find_imbalance/environment.yml
+++ b/pipelines/nf-atacseq/modules/local/wasp2_find_imbalance/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::wasp2=1.4.1
+  - bioconda::wasp2=1.5.0

--- a/pipelines/nf-atacseq/modules/local/wasp2_find_imbalance/main.nf
+++ b/pipelines/nf-atacseq/modules/local/wasp2_find_imbalance/main.nf
@@ -4,8 +4,8 @@ process WASP2_FIND_IMBALANCE {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/mcvickerlab/wasp2:1.4.1' :
-        'ghcr.io/mcvickerlab/wasp2:1.4.1' }"
+        'docker://ghcr.io/mcvickerlab/wasp2:1.5.0' :
+        'ghcr.io/mcvickerlab/wasp2:1.5.0' }"
 
     input:
     tuple val(meta), path(counts)
@@ -66,7 +66,7 @@ process WASP2_FIND_IMBALANCE {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        wasp2: 1.4.1
+        wasp2: 1.5.0
     END_VERSIONS
     """
 }

--- a/pipelines/nf-atacseq/modules/local/wasp2_make_reads.nf
+++ b/pipelines/nf-atacseq/modules/local/wasp2_make_reads.nf
@@ -4,8 +4,8 @@ process WASP2_MAKE_READS {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/mcvickerlab/wasp2:1.4.1' :
-        'ghcr.io/mcvickerlab/wasp2:1.4.1' }"
+        'docker://ghcr.io/mcvickerlab/wasp2:1.5.0' :
+        'ghcr.io/mcvickerlab/wasp2:1.5.0' }"
 
     input:
     tuple val(meta), path(bam), path(bai)
@@ -73,7 +73,7 @@ process WASP2_MAKE_READS {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        wasp2: 1.4.1
+        wasp2: 1.5.0
     END_VERSIONS
     """
 }

--- a/pipelines/nf-atacseq/modules/local/wasp2_make_reads/environment.yml
+++ b/pipelines/nf-atacseq/modules/local/wasp2_make_reads/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::wasp2=1.4.1
+  - bioconda::wasp2=1.5.0

--- a/pipelines/nf-atacseq/modules/local/wasp2_make_reads/main.nf
+++ b/pipelines/nf-atacseq/modules/local/wasp2_make_reads/main.nf
@@ -4,8 +4,8 @@ process WASP2_MAKE_READS {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/mcvickerlab/wasp2:1.4.1' :
-        'ghcr.io/mcvickerlab/wasp2:1.4.1' }"
+        'docker://ghcr.io/mcvickerlab/wasp2:1.5.0' :
+        'ghcr.io/mcvickerlab/wasp2:1.5.0' }"
 
     input:
     tuple val(meta), path(bam), path(bai)
@@ -91,7 +91,7 @@ process WASP2_MAKE_READS {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        wasp2: 1.4.1
+        wasp2: 1.5.0
     END_VERSIONS
     """
 }

--- a/pipelines/nf-atacseq/nextflow.config
+++ b/pipelines/nf-atacseq/nextflow.config
@@ -176,7 +176,7 @@ env {
 }
 
 // Container overrides
-def wasp2_container = 'ghcr.io/mcvickerlab/wasp2:1.4.1'
+def wasp2_container = 'ghcr.io/mcvickerlab/wasp2:1.5.0'
 def bwa_samtools_container = 'community.wave.seqera.io/library/bwa_htslib_samtools:56c9f8d5201889a4'
 def samtools_container = 'quay.io/biocontainers/samtools:1.19--h50ea8bc_0'
 

--- a/pipelines/nf-modules/modules/wasp2/analyze/main.nf
+++ b/pipelines/nf-modules/modules/wasp2/analyze/main.nf
@@ -4,8 +4,8 @@ process WASP2_ANALYZE {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/mcvickerlab/wasp2:1.4.1' :
-        'ghcr.io/mcvickerlab/wasp2:1.4.1' }"
+        'docker://ghcr.io/mcvickerlab/wasp2:1.5.0' :
+        'ghcr.io/mcvickerlab/wasp2:1.5.0' }"
 
     input:
     tuple val(meta), path(counts)
@@ -65,7 +65,7 @@ process WASP2_ANALYZE {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        wasp2: 1.4.1
+        wasp2: 1.5.0
         python: 3.11.0
     END_VERSIONS
     """

--- a/pipelines/nf-modules/modules/wasp2/analyze_imbalance/main.nf
+++ b/pipelines/nf-modules/modules/wasp2/analyze_imbalance/main.nf
@@ -4,8 +4,8 @@ process WASP2_ANALYZE_IMBALANCE {
 
     conda "${moduleDir}/../environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/mcvickerlab/wasp2:1.4.1' :
-        'ghcr.io/mcvickerlab/wasp2:1.4.1' }"
+        'docker://ghcr.io/mcvickerlab/wasp2:1.5.0' :
+        'ghcr.io/mcvickerlab/wasp2:1.5.0' }"
 
     input:
     tuple val(meta), path(counts)

--- a/pipelines/nf-modules/modules/wasp2/count/main.nf
+++ b/pipelines/nf-modules/modules/wasp2/count/main.nf
@@ -4,8 +4,8 @@ process WASP2_COUNT {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/mcvickerlab/wasp2:1.4.1' :
-        'ghcr.io/mcvickerlab/wasp2:1.4.1' }"
+        'docker://ghcr.io/mcvickerlab/wasp2:1.5.0' :
+        'ghcr.io/mcvickerlab/wasp2:1.5.0' }"
 
     input:
     tuple val(meta), path(bam), path(bai)
@@ -69,7 +69,7 @@ process WASP2_COUNT {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        wasp2: 1.4.1
+        wasp2: 1.5.0
         python: 3.11.0
     END_VERSIONS
     """

--- a/pipelines/nf-modules/modules/wasp2/count_alleles/main.nf
+++ b/pipelines/nf-modules/modules/wasp2/count_alleles/main.nf
@@ -4,8 +4,8 @@ process WASP2_COUNT_ALLELES {
 
     conda "${moduleDir}/../environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/mcvickerlab/wasp2:1.4.1' :
-        'ghcr.io/mcvickerlab/wasp2:1.4.1' }"
+        'docker://ghcr.io/mcvickerlab/wasp2:1.5.0' :
+        'ghcr.io/mcvickerlab/wasp2:1.5.0' }"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/pipelines/nf-modules/modules/wasp2/count_sc/main.nf
+++ b/pipelines/nf-modules/modules/wasp2/count_sc/main.nf
@@ -12,8 +12,8 @@ process WASP2_COUNT_SC {
 
     conda "${moduleDir}/../environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/mcvickerlab/wasp2:1.4.1' :
-        'ghcr.io/mcvickerlab/wasp2:1.4.1' }"
+        'docker://ghcr.io/mcvickerlab/wasp2:1.5.0' :
+        'ghcr.io/mcvickerlab/wasp2:1.5.0' }"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/pipelines/nf-modules/modules/wasp2/environment.yml
+++ b/pipelines/nf-modules/modules/wasp2/environment.yml
@@ -23,4 +23,4 @@ dependencies:
   - typer
   - rich
   - pip:
-    - wasp2==1.4.1
+    - wasp2==1.5.0

--- a/pipelines/nf-modules/modules/wasp2/filter_remapped/main.nf
+++ b/pipelines/nf-modules/modules/wasp2/filter_remapped/main.nf
@@ -4,8 +4,8 @@ process WASP2_FILTER_REMAPPED {
 
     conda "${moduleDir}/../environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/mcvickerlab/wasp2:1.4.1' :
-        'ghcr.io/mcvickerlab/wasp2:1.4.1' }"
+        'docker://ghcr.io/mcvickerlab/wasp2:1.5.0' :
+        'ghcr.io/mcvickerlab/wasp2:1.5.0' }"
 
     input:
     tuple val(meta), path(remapped_bam), path(remapped_bai)

--- a/pipelines/nf-modules/modules/wasp2/map/main.nf
+++ b/pipelines/nf-modules/modules/wasp2/map/main.nf
@@ -4,8 +4,8 @@ process WASP2_MAP_MAKE_READS {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/mcvickerlab/wasp2:1.4.1' :
-        'ghcr.io/mcvickerlab/wasp2:1.4.1' }"
+        'docker://ghcr.io/mcvickerlab/wasp2:1.5.0' :
+        'ghcr.io/mcvickerlab/wasp2:1.5.0' }"
 
     input:
     tuple val(meta), path(bam), path(bai)
@@ -148,7 +148,7 @@ process WASP2_MAP_MAKE_READS {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        wasp2: 1.4.1
+        wasp2: 1.5.0
         python: 3.11.0
         samtools: 1.17
     END_VERSIONS
@@ -161,8 +161,8 @@ process WASP2_MAP_FILTER {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/mcvickerlab/wasp2:1.4.1' :
-        'ghcr.io/mcvickerlab/wasp2:1.4.1' }"
+        'docker://ghcr.io/mcvickerlab/wasp2:1.5.0' :
+        'ghcr.io/mcvickerlab/wasp2:1.5.0' }"
 
     input:
     tuple val(meta), path(remapped_bam), path(remapped_bai)
@@ -237,7 +237,7 @@ process WASP2_MAP_FILTER {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        wasp2: 1.4.1
+        wasp2: 1.5.0
         python: 3.11.0
         samtools: 1.17
     END_VERSIONS

--- a/pipelines/nf-modules/modules/wasp2/ml_output/main.nf
+++ b/pipelines/nf-modules/modules/wasp2/ml_output/main.nf
@@ -4,8 +4,8 @@ process WASP2_ML_OUTPUT {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/mcvickerlab/wasp2:1.4.1' :
-        'ghcr.io/mcvickerlab/wasp2:1.4.1' }"
+        'docker://ghcr.io/mcvickerlab/wasp2:1.5.0' :
+        'ghcr.io/mcvickerlab/wasp2:1.5.0' }"
 
     input:
     tuple val(meta), path(counts)

--- a/pipelines/nf-modules/modules/wasp2/unified_make_reads/main.nf
+++ b/pipelines/nf-modules/modules/wasp2/unified_make_reads/main.nf
@@ -4,8 +4,8 @@ process WASP2_UNIFIED_MAKE_READS {
 
     conda "${moduleDir}/../environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/mcvickerlab/wasp2:1.4.1' :
-        'ghcr.io/mcvickerlab/wasp2:1.4.1' }"
+        'docker://ghcr.io/mcvickerlab/wasp2:1.5.0' :
+        'ghcr.io/mcvickerlab/wasp2:1.5.0' }"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/pipelines/nf-modules/modules/wasp2/vcf_to_bed/main.nf
+++ b/pipelines/nf-modules/modules/wasp2/vcf_to_bed/main.nf
@@ -4,8 +4,8 @@ process WASP2_VCF_TO_BED {
 
     conda "${moduleDir}/../environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/mcvickerlab/wasp2:1.4.1' :
-        'ghcr.io/mcvickerlab/wasp2:1.4.1' }"
+        'docker://ghcr.io/mcvickerlab/wasp2:1.5.0' :
+        'ghcr.io/mcvickerlab/wasp2:1.5.0' }"
 
     input:
     tuple val(meta), path(vcf), path(vcf_index)

--- a/pipelines/nf-modules/nextflow.config
+++ b/pipelines/nf-modules/nextflow.config
@@ -9,7 +9,7 @@
 //   - Docker: ghcr.io/mcvickerlab/wasp2:<version>
 //   - Singularity: docker://ghcr.io/mcvickerlab/wasp2:<version>
 //
-def wasp2_container_version = '1.4.1'
+def wasp2_container_version = '1.5.0'
 
 params {
     // WASP2 container references

--- a/pipelines/nf-outrider/modules/local/aggregate_counts/main.nf
+++ b/pipelines/nf-outrider/modules/local/aggregate_counts/main.nf
@@ -4,8 +4,8 @@ process AGGREGATE_COUNTS {
 
     conda "${moduleDir}/../../../environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/mcvickerlab/wasp2:1.4.1' :
-        'ghcr.io/mcvickerlab/wasp2:1.4.1' }"
+        'docker://ghcr.io/mcvickerlab/wasp2:1.5.0' :
+        'ghcr.io/mcvickerlab/wasp2:1.5.0' }"
 
     input:
     tuple val(meta), path(counts)

--- a/pipelines/nf-outrider/modules/local/mae_detect/main.nf
+++ b/pipelines/nf-outrider/modules/local/mae_detect/main.nf
@@ -4,8 +4,8 @@ process MAE_DETECT {
 
     conda "${moduleDir}/../../../environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/mcvickerlab/wasp2:1.4.1' :
-        'ghcr.io/mcvickerlab/wasp2:1.4.1' }"
+        'docker://ghcr.io/mcvickerlab/wasp2:1.5.0' :
+        'ghcr.io/mcvickerlab/wasp2:1.5.0' }"
 
     input:
     tuple val(meta), path(counts)

--- a/pipelines/nf-outrider/modules/local/merge_counts/main.nf
+++ b/pipelines/nf-outrider/modules/local/merge_counts/main.nf
@@ -4,8 +4,8 @@ process MERGE_COUNTS {
 
     conda "${moduleDir}/../../../environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/mcvickerlab/wasp2:1.4.1' :
-        'ghcr.io/mcvickerlab/wasp2:1.4.1' }"
+        'docker://ghcr.io/mcvickerlab/wasp2:1.5.0' :
+        'ghcr.io/mcvickerlab/wasp2:1.5.0' }"
 
     input:
     path gene_counts  // Collection of gene count files

--- a/pipelines/nf-outrider/nextflow.config
+++ b/pipelines/nf-outrider/nextflow.config
@@ -181,7 +181,7 @@ env {
 }
 
 // Container overrides
-def wasp2_container = 'ghcr.io/mcvickerlab/wasp2:1.4.1'
+def wasp2_container = 'ghcr.io/mcvickerlab/wasp2:1.5.0'
 def outrider_container = 'quay.io/biocontainers/bioconductor-outrider:1.26.3--r44he5774e6_0'
 process {
     withName: 'WASP2_COUNT|WASP2_ML_OUTPUT|AGGREGATE_COUNTS|MERGE_COUNTS|MAE_DETECT' {

--- a/pipelines/nf-rnaseq/modules/local/wasp2_analyze_imbalance/main.nf
+++ b/pipelines/nf-rnaseq/modules/local/wasp2_analyze_imbalance/main.nf
@@ -4,8 +4,8 @@ process WASP2_ANALYZE_IMBALANCE {
 
     conda "${moduleDir}/../environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/mcvickerlab/wasp2:1.4.1' :
-        'ghcr.io/mcvickerlab/wasp2:1.4.1' }"
+        'docker://ghcr.io/mcvickerlab/wasp2:1.5.0' :
+        'ghcr.io/mcvickerlab/wasp2:1.5.0' }"
 
     input:
     tuple val(meta), path(counts)

--- a/pipelines/nf-rnaseq/modules/local/wasp2_count_alleles/main.nf
+++ b/pipelines/nf-rnaseq/modules/local/wasp2_count_alleles/main.nf
@@ -4,8 +4,8 @@ process WASP2_COUNT_ALLELES {
 
     conda "${moduleDir}/../environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/mcvickerlab/wasp2:1.4.1' :
-        'ghcr.io/mcvickerlab/wasp2:1.4.1' }"
+        'docker://ghcr.io/mcvickerlab/wasp2:1.5.0' :
+        'ghcr.io/mcvickerlab/wasp2:1.5.0' }"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/pipelines/nf-rnaseq/modules/local/wasp2_filter_remapped/main.nf
+++ b/pipelines/nf-rnaseq/modules/local/wasp2_filter_remapped/main.nf
@@ -4,8 +4,8 @@ process WASP2_FILTER_REMAPPED {
 
     conda "${moduleDir}/../environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/mcvickerlab/wasp2:1.4.1' :
-        'ghcr.io/mcvickerlab/wasp2:1.4.1' }"
+        'docker://ghcr.io/mcvickerlab/wasp2:1.5.0' :
+        'ghcr.io/mcvickerlab/wasp2:1.5.0' }"
 
     input:
     tuple val(meta), path(remapped_bam), path(remapped_bai)

--- a/pipelines/nf-rnaseq/modules/local/wasp2_ml_output/main.nf
+++ b/pipelines/nf-rnaseq/modules/local/wasp2_ml_output/main.nf
@@ -4,8 +4,8 @@ process WASP2_ML_OUTPUT {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/mcvickerlab/wasp2:1.4.1' :
-        'ghcr.io/mcvickerlab/wasp2:1.4.1' }"
+        'docker://ghcr.io/mcvickerlab/wasp2:1.5.0' :
+        'ghcr.io/mcvickerlab/wasp2:1.5.0' }"
 
     input:
     tuple val(meta), path(counts)

--- a/pipelines/nf-rnaseq/modules/local/wasp2_unified_make_reads/main.nf
+++ b/pipelines/nf-rnaseq/modules/local/wasp2_unified_make_reads/main.nf
@@ -4,8 +4,8 @@ process WASP2_UNIFIED_MAKE_READS {
 
     conda "${moduleDir}/../environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/mcvickerlab/wasp2:1.4.1' :
-        'ghcr.io/mcvickerlab/wasp2:1.4.1' }"
+        'docker://ghcr.io/mcvickerlab/wasp2:1.5.0' :
+        'ghcr.io/mcvickerlab/wasp2:1.5.0' }"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/pipelines/nf-rnaseq/nextflow.config
+++ b/pipelines/nf-rnaseq/nextflow.config
@@ -137,7 +137,7 @@ profiles {
 }
 
 // Container overrides
-def wasp2_container = 'ghcr.io/mcvickerlab/wasp2:1.4.1'
+def wasp2_container = 'ghcr.io/mcvickerlab/wasp2:1.5.0'
 def star_container = 'community.wave.seqera.io/library/htslib_samtools_star_gawk:ae438e9a604351a4'
 process {
     withName: 'WASP2_UNIFIED_MAKE_READS|WASP2_FILTER_REMAPPED|WASP2_COUNT_ALLELES|WASP2_ANALYZE_IMBALANCE|WASP2_ML_OUTPUT' {

--- a/pipelines/nf-scatac/modules/local/scatac_add_haplotype_layers/main.nf
+++ b/pipelines/nf-scatac/modules/local/scatac_add_haplotype_layers/main.nf
@@ -20,8 +20,8 @@ process SCATAC_ADD_HAPLOTYPE_LAYERS {
 
     conda "${projectDir}/../nf-modules/modules/wasp2/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/mcvickerlab/wasp2:1.4.1' :
-        'ghcr.io/mcvickerlab/wasp2:1.4.1' }"
+        'docker://ghcr.io/mcvickerlab/wasp2:1.5.0' :
+        'ghcr.io/mcvickerlab/wasp2:1.5.0' }"
 
     input:
     tuple val(meta), path(anndata)

--- a/pipelines/nf-scatac/modules/local/scatac_count_alleles/main.nf
+++ b/pipelines/nf-scatac/modules/local/scatac_count_alleles/main.nf
@@ -15,8 +15,8 @@ process SCATAC_COUNT_ALLELES {
 
     conda "${projectDir}/../nf-modules/modules/wasp2/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/mcvickerlab/wasp2:1.4.1' :
-        'ghcr.io/mcvickerlab/wasp2:1.4.1' }"
+        'docker://ghcr.io/mcvickerlab/wasp2:1.5.0' :
+        'ghcr.io/mcvickerlab/wasp2:1.5.0' }"
 
     input:
     tuple val(meta), path(fragments), path(fragments_tbi), path(snp_bed)

--- a/pipelines/nf-scatac/modules/local/scatac_create_anndata/main.nf
+++ b/pipelines/nf-scatac/modules/local/scatac_create_anndata/main.nf
@@ -19,8 +19,8 @@ process SCATAC_CREATE_ANNDATA {
 
     conda "${projectDir}/../nf-modules/modules/wasp2/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/mcvickerlab/wasp2:1.4.1' :
-        'ghcr.io/mcvickerlab/wasp2:1.4.1' }"
+        'docker://ghcr.io/mcvickerlab/wasp2:1.5.0' :
+        'ghcr.io/mcvickerlab/wasp2:1.5.0' }"
 
     input:
     tuple val(meta), path(counts)

--- a/pipelines/nf-scatac/modules/local/scatac_pseudobulk/main.nf
+++ b/pipelines/nf-scatac/modules/local/scatac_pseudobulk/main.nf
@@ -17,8 +17,8 @@ process SCATAC_PSEUDOBULK {
 
     conda "${projectDir}/../nf-modules/modules/wasp2/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://ghcr.io/mcvickerlab/wasp2:1.4.1' :
-        'ghcr.io/mcvickerlab/wasp2:1.4.1' }"
+        'docker://ghcr.io/mcvickerlab/wasp2:1.5.0' :
+        'ghcr.io/mcvickerlab/wasp2:1.5.0' }"
 
     input:
     tuple val(meta), path(cell_counts)

--- a/pipelines/nf-scatac/nextflow.config
+++ b/pipelines/nf-scatac/nextflow.config
@@ -63,7 +63,7 @@ try {
 }
 
 // Container version - override all WASP2/SCATAC processes with the release pin
-def wasp2_container = 'ghcr.io/mcvickerlab/wasp2:1.4.1'
+def wasp2_container = 'ghcr.io/mcvickerlab/wasp2:1.5.0'
 
 process {
     withName: 'SCATAC_COUNT_ALLELES|SCATAC_CREATE_ANNDATA|SCATAC_ADD_HAPLOTYPE_LAYERS|SCATAC_PSEUDOBULK|WASP2_.*|SINTO_FRAGMENTS' {

--- a/pixi.toml
+++ b/pixi.toml
@@ -7,7 +7,7 @@
 
 [project]
 name = "wasp2"
-version = "1.4.1"
+version = "1.5.0"
 description = "Allele-specific analysis of next-generation sequencing data with Rust acceleration"
 channels = ["conda-forge", "bioconda"]
 platforms = ["linux-64", "linux-aarch64", "osx-arm64", "osx-64"]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "wasp2"
-version = "1.4.1"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "coitrees",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasp2"
-version = "1.4.1"
+version = "1.5.0"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
## Summary
- synchronize Cargo, pixi, Python package metadata, containers, Galaxy, Nextflow, docs, and citation metadata at 1.5.0
- record the 1.5.0 statistical, counting, scATAC, ecosystem, and release-hardening changes
- leave publishing gated on promotion to master and a verified signed tag

## Validation
- exact CPython 3.10 wheel built and installed as wasp2 1.5.0
- Python: 171 passed, 18 skipped
- Rust: 116 passed, 7 ignored
- strict Ruff and Clippy clean
- Sphinx warnings-as-errors build passed
- Planemo 0.75.44 lint passed for all four Galaxy wrappers
- release version consistency check passed

No downstream analysis outputs or cohort-shared analysis implementation are included.