### PR TITLE
Fix macOS Intel release installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ All notable changes to WASP2 will be documented in this file.
 - Galaxy wrappers now match current CLI inputs and outputs, use datasets instead of job-local JSON
   paths between jobs, and run all four functional tests successfully.
 - BAM merging uses portable `samtools merge` positional output syntax supported by older samtools.
+- macOS Intel installs constrain Numba to the final release line with prebuilt Intel llvmlite
+  wheels, avoiding an unsupported LLVM source build during installation.
 
 ### Security
 - GitHub Actions are commit-pinned with read-only default tokens, dependency review, CodeQL,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,8 @@ dependencies = [
     "pybedtools>=0.9.0",
     "anndata>=0.8.0,<0.12.0",
     "scanpy>=1.10.0",
-    "numba>=0.59.0",
+    "numba>=0.59.0,<0.63.0; sys_platform == 'darwin' and platform_machine == 'x86_64'",
+    "numba>=0.59.0; sys_platform != 'darwin' or platform_machine != 'x86_64'",
     "typer>=0.12.0",
     "rich>=13.0.0",
 ]


### PR DESCRIPTION
## Summary

- constrain Numba only on macOS Intel to the final release line that ships Intel llvmlite wheels
- preserve current Numba resolution on macOS ARM and Linux
- document the install compatibility fix in the 1.5.0 changelog

## Root cause

The 1.5.0 release dry run built all macOS Intel WASP2 wheels successfully, but the exact-wheel smoke tests resolved Numba 0.66.0 and llvmlite 0.48.0. llvmlite 0.48.0 no longer publishes macOS Intel wheels and requires LLVM 22 for source builds, so installation failed on every supported Intel Python version.

## Validation

- `python scripts/release_version.py --check`
- PEP 508 requirement parsing passed
- macOS Intel resolver checks for Python 3.10-3.13 each select `numba==0.62.1` and `llvmlite==0.45.1`
- macOS ARM and Linux resolver checks continue to select `numba==0.66.0` and `llvmlite==0.48.0`
- generated 1.5.0 sdist contains both platform markers and passes `twine check`

No Rust, Python analysis, CLI, statistics, or downstream analysis code is changed.
