### PR TITLE
Fix macOS Intel release installs on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ All notable changes to WASP2 will be documented in this file.
 - Galaxy wrappers now match current CLI inputs and outputs, use datasets instead of job-local JSON
   paths between jobs, and run all four functional tests successfully.
 - BAM merging uses portable `samtools merge` positional output syntax supported by older samtools.
+- macOS Intel installs constrain Numba to the final release line with prebuilt Intel llvmlite
+  wheels, avoiding an unsupported LLVM source build during installation.
 
 ### Security
 - GitHub Actions are commit-pinned with read-only default tokens, dependency review, CodeQL,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,8 @@ dependencies = [
     "pybedtools>=0.9.0",
     "anndata>=0.8.0,<0.12.0",
     "scanpy>=1.10.0",
-    "numba>=0.59.0",
+    "numba>=0.59.0,<0.63.0; sys_platform == 'darwin' and platform_machine == 'x86_64'",
+    "numba>=0.59.0; sys_platform != 'darwin' or platform_machine != 'x86_64'",
     "typer>=0.12.0",
     "rich>=13.0.0",
 ]


### PR DESCRIPTION
## Summary

Apply the validated macOS Intel installation fix to `master` before rerunning the WASP2 1.5.0 release workflow.

## Included change

- constrain Numba only on macOS Intel to the 0.62 release line, which resolves llvmlite 0.45.1 binary wheels for Python 3.10-3.13
- leave macOS ARM and Linux on current Numba/llvmlite releases
- document the fix in the 1.5.0 changelog

This branch is based directly on current `master` and differs in exactly `pyproject.toml` and `CHANGELOG.md`. No analysis, Rust, Python implementation, CLI, statistics, or downstream result files are included.

## Validation

- dev PR #126 passed all five protected gates, hosted Galaxy tests, and macOS package build
- the superseded dev-to-master PR #127 passed all five protected gates but was unmergeable because prior squash promotion left equivalent trees on divergent histories
- macOS Intel resolver checks for Python 3.10-3.13 select `numba==0.62.1` and `llvmlite==0.45.1`
- macOS ARM and Linux remain on `numba==0.66.0` and `llvmlite==0.48.0`
- generated 1.5.0 sdist passes `twine check`
