### PR TITLE
fix(release): use native ARM smoke runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,7 +259,7 @@ jobs:
   container-smoke:
     name: Container smoke (${{ matrix.platform }})
     needs: [validate, package]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     permissions:
       contents: read
@@ -267,13 +267,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {platform: linux/amd64, tag: amd64}
-          - {platform: linux/arm64, tag: arm64}
+          - {runner: ubuntu-24.04, platform: linux/amd64, tag: amd64}
+          - {runner: ubuntu-24.04-arm, platform: linux/arm64, tag: arm64}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-      - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392  # v3
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
       - name: Build local release image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6


### PR DESCRIPTION
## Summary

- run the AMD64 container preflight on ubuntu-24.04
- run the ARM64 container preflight on the repository's existing ubuntu-24.04-arm runner class
- remove unnecessary QEMU setup from the per-architecture smoke matrix

## Why

Release dry run 29373783684 showed the AMD64 image building and passing in 8.5 minutes while the QEMU ARM64 build remained in the image-build step for more than 30 minutes. Native ARM runners are already used by the release wheel matrix, so emulation adds cost and timeout risk without increasing validation coverage.

## Validation

- actionlint v1.7.12
- git diff --check
- one release workflow file changed

This changes only release CI runner selection. It does not alter software, statistics, CLI behavior, or analysis code.
