### PR TITLE
fix(release): use native ARM smoke runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,7 +259,7 @@ jobs:
   container-smoke:
     name: Container smoke (${{ matrix.platform }})
     needs: [validate, package]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     permissions:
       contents: read
@@ -267,13 +267,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {platform: linux/amd64, tag: amd64}
-          - {platform: linux/arm64, tag: arm64}
+          - {runner: ubuntu-24.04, platform: linux/amd64, tag: amd64}
+          - {runner: ubuntu-24.04-arm, platform: linux/arm64, tag: arm64}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-      - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392  # v3
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
       - name: Build local release image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6


### PR DESCRIPTION
## Summary

Promote the validated native ARM release-preflight runner selection from dev to master.

- AMD64 preflight uses ubuntu-24.04
- ARM64 preflight uses ubuntu-24.04-arm
- per-architecture smoke tests no longer install QEMU

## Provenance

- dev PR: #131
- dev merge: ab9041bb09616edcaa3e244472275d8f0ba0d742
- clean cherry-pick onto current master
- promotion tree is byte-identical to current dev

Release dry run 29373783684 demonstrated the reason for this correction: AMD64 passed in 8.5 minutes while emulated ARM64 remained in its build step for more than 43 minutes before the obsolete run was canceled.

Only the release workflow changes. No software or analysis code is included.
