### PR TITLE
feat: add donor-local inference and finalize 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,16 @@ All notable changes to WASP2 will be documented in this file.
 
 ## [Unreleased]
 
-## [1.5.0] - 2026-07-14
+## [1.5.0] - 2026-07-21
 
 ### Added
 - `wasp2-count count-cohort` for one-final-BAM-per-donor bulk counting with explicit
   `donor_id`/`vcf_sample` mapping, atomic locked outputs, and SHA-256 provenance manifests.
 - Linear-dispersion and donor-specific-dispersion beta-binomial implementations in the Rust
   analysis API, including phased feature-level inference.
+- Donor-local bulk imbalance orchestration through `wasp2-analyze find-imbalance` with explicit
+  SNV or feature units, global or per-donor nuisance fitting, donor-local inference and BH
+  correction, manifest pinning, and non-overwriting result, dispersion, QC, and provenance files.
 - `--per-variant` / `--snv-solo` for independent SNV tests and explicit `--region_col` support
   for feature- or peak-level aggregation.
 - A Rust single-cell ATAC allele counter with chromosome-parallel execution and Python fallback.
@@ -22,6 +25,8 @@ All notable changes to WASP2 will be documented in this file.
   with the archived Python implementation; allele-string genotypes do not imply cross-SNV phase.
 - `--phased` and `--region_col` are forwarded to the Rust backend; unsupported `--groupby`
   requests fail closed and direct users to `--region_col <parent_column>`.
+- SNV analysis is unphased by contract, while feature analysis supports phased and unphased
+  likelihoods without pooling effect inference across donors.
 - Single-cell AnnData output now follows the scverse `obs=cells`, `var=variants` orientation.
 - Packaging derives the Python version from installed metadata and synchronizes Cargo, pixi,
   containers, Galaxy, Nextflow, documentation, and citation metadata from one release command.
@@ -34,6 +39,10 @@ All notable changes to WASP2 will be documented in this file.
 - Unphased multi-SNV likelihoods now use log-space dynamic programming to prevent underflow.
 - Linear inference uses per-SNV dispersion throughout the alternative optimization, phased
   donor-specific inference uses each observation's donor dispersion, and LRTs are non-negative.
+- Linear nuisance fits now standardize raw depth and persist the fitted center and scale with both
+  coefficients so fixed global fits are reused exactly in every donor-local run.
+- Ambiguous multi-allelic count rows are rejected instead of being silently coerced into
+  biallelic SNV identities.
 - Bulk counts use `UInt32`, and single-cell pseudobulk/observation sums widen safely instead of
   overflowing at 65,535; single-cell counting also works without an optional feature file.
 - Count-analysis TSV parsing is header-driven, so `pos0`, `GT`, sample, and donor metadata cannot

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,7 +23,7 @@ authors:
     affiliation: "Salk Institute for Biological Studies"
 
 version: "1.5.0"
-date-released: "2026-07-14"
+date-released: "2026-07-21"
 license: MIT
 
 repository-code: "https://github.com/mcvickerlab/WASP2"

--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ wasp2-analyze find-imbalance cohort_counts \
 `--dispersion-scope per-donor` is the default. `--dispersion-scope global`
 fits one nuisance model over unique eligible donor-SNV rows and reuses that exact
 fit for every included donor; testing and BH correction remain donor-local. Both
-`single` and `linear` dispersion models are supported.
+`single` and `linear` dispersion models are supported. Linear fits record and
+reuse `linear_d1`, `linear_d2`, `linear_depth_center`, and
+`linear_depth_scale` together.
 
 Feature analysis preserves one SNV in every overlapping feature. `peak` remains
 an alias for `feature`:
@@ -149,7 +151,10 @@ The donor-local route defaults to pseudocount 0. It writes
 refuses to overwrite any of them. For standalone legacy count tables only,
 `sample` is accepted and normalized to `donor_id`; providing both columns is an
 error. Use `--expected-manifest-sha256` to require an externally trusted locked
-bundle manifest.
+bundle manifest. An input `snv_id` is preserved exactly after validating its
+donor and allele identity; coordinate-based IDs are synthesized only when the
+column is absent. Dispersion and provenance metadata report optimizer status
+only when Rust provides it; `parameters_returned` does not assert convergence.
 
 ## Single-Cell Example
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,43 @@ to retain peak identifiers for feature-level analysis.
 wasp2-analyze find-imbalance counts.tsv -o ai_results.tsv
 ```
 
+### Donor-local cohort analysis
+
+Analyze the locked count directory (or its `count_manifest.json` or
+`counts.tsv.gz`) with an explicit unit. SNV analysis rejects `--phased` and tests
+each variant independently within each donor:
+
+```bash
+wasp2-analyze find-imbalance cohort_counts \
+  --scope per-donor --unit snv --min-donor-observations 50 \
+  -o atac_snv_results.tsv
+```
+
+`--dispersion-scope per-donor` is the default. `--dispersion-scope global`
+fits one nuisance model over unique eligible donor-SNV rows and reuses that exact
+fit for every included donor; testing and BH correction remain donor-local. Both
+`single` and `linear` dispersion models are supported.
+
+Feature analysis preserves one SNV in every overlapping feature. `peak` remains
+an alias for `feature`:
+
+```bash
+wasp2-count count-cohort donors.tsv variants.vcf.gz feature_counts \
+  --unit feature --regions peaks.bed
+
+wasp2-analyze find-imbalance feature_counts \
+  --scope per-donor --unit feature --model linear --phased \
+  -o atac_feature_results.tsv
+```
+
+The donor-local route defaults to pseudocount 0. It writes
+`atac_feature_results.tsv`, `atac_feature_results.dispersion.tsv`,
+`atac_feature_results.qc.tsv`, and `atac_feature_results.provenance.json` and
+refuses to overwrite any of them. For standalone legacy count tables only,
+`sample` is accepted and normalized to `donor_id`; providing both columns is an
+error. Use `--expected-manifest-sha256` to require an externally trusted locked
+bundle manifest.
+
 ## Single-Cell Example
 
 ```bash

--- a/docs/source/api/analysis.rst
+++ b/docs/source/api/analysis.rst
@@ -44,6 +44,14 @@ run_analysis
    :undoc-members:
    :show-inheritance:
 
+run_analysis_per_donor
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: analysis.run_analysis_per_donor
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 run_analysis_sc
 ~~~~~~~~~~~~~~~
 

--- a/docs/source/user_guide/analysis.rst
+++ b/docs/source/user_guide/analysis.rst
@@ -61,12 +61,24 @@ fits unique eligible donor-SNV rows once and reuses the returned fit ID and
 parameters unchanged in each donor run. In both modes, effect inference and
 Benjamini-Hochberg correction are independent within each donor.
 
+The ``linear`` model carries four inseparable nuisance values:
+``linear_d1``, ``linear_d2``, ``linear_depth_center``, and
+``linear_depth_scale``. The fit ID includes all four, and fixed-nuisance donor
+runs must echo all four exactly. The dispersion TSV and provenance JSON retain
+these values. They retain optimizer or fit status fields when Rust supplies
+them; otherwise ``fit_status=parameters_returned`` records only that a usable
+parameter payload was returned and does not claim optimizer convergence.
+
 The donor-local route defaults to pseudocount 0 and creates result,
 ``.dispersion.tsv``, ``.qc.tsv``, and ``.provenance.json`` artifacts without
 overwriting existing files. ``--expected-manifest-sha256`` can pin the locked
 bundle manifest to an external digest. Standalone legacy tables may use
 ``sample`` instead of ``donor_id``; a locked bundle may not, and a table with
-both columns is rejected.
+both columns is rejected. If the count table has ``snv_id``, its exact text is
+retained after enforcing a one-to-one mapping with donor, chromosome, position,
+reference, and alternate allele. Only tables without the column receive a
+synthesized ``chrom:pos:ref:alt`` identifier, so canonical zero-based input IDs
+are not rewritten.
 
 Single-Cell Analysis
 --------------------
@@ -124,9 +136,10 @@ Defaults and contracts
 - Beta-binomial LRT: :math:`\rho` is held at its **null-model MLE** while
   maximizing the alternative likelihood over :math:`\mu` (profile likelihood,
   df = 1). :math:`\rho` is not jointly re-estimated under :math:`H_1`.
-- Dispersion optimizer bounds :math:`\rho \in (10^{-6},\, 1-10^{-6})`; the
-  linear-dispersion model clips the logit at :math:`\pm 10` for numerical
-  stability on extreme :math:`N`.
+- Dispersion optimizer bounds :math:`\rho \in (10^{-6},\, 1-10^{-6})`. The
+  linear model uses raw-depth standardization,
+  :math:`\rho(N)=\operatorname{expit}(d_1 + d_2(N-c)/s)`, and persists the fitted
+  center :math:`c` and positive scale :math:`s` with :math:`d_1` and :math:`d_2`.
 - FDR correction uses :func:`scipy.stats.false_discovery_control` with
   ``method='bh'`` (Benjamini–Hochberg). ``scipy`` raises on NaN p-values,
   but a hand-written BH loop using ``np.minimum.accumulate`` silently

--- a/docs/source/user_guide/analysis.rst
+++ b/docs/source/user_guide/analysis.rst
@@ -33,6 +33,41 @@ Useful options:
 * ``--region_col``: explicit region column name if auto-detection is not desired
 * ``--groupby``: group on an alternate annotation column, such as a parent gene column
 
+Donor-Local Bulk Analysis
+-------------------------
+
+Locked cohort count bundles use ``donor_id`` as the donor identity. Analyze the
+bundle directory, its ``count_manifest.json``, or its locked ``counts.tsv.gz``:
+
+.. code-block:: bash
+
+   wasp2-analyze find-imbalance cohort_counts \
+     --scope per-donor \
+     --unit snv \
+     --model single \
+     --dispersion-scope per-donor \
+     --min-donor-observations 50 \
+     --output donor_snv.tsv
+
+The supported units are ``snv`` and ``feature``; ``peak`` is an alias for
+``feature``. SNV analysis is unphased. Feature analysis may use ``--phased`` and
+uses the locked ``region`` column, or an explicit ``--region-col`` for a
+standalone count table. Overlapping feature memberships are retained for feature
+tests but contribute only one donor-SNV row to dispersion fitting.
+
+``--dispersion-scope per-donor`` fits ``single`` or ``linear`` nuisance
+parameters independently for each included donor. ``--dispersion-scope global``
+fits unique eligible donor-SNV rows once and reuses the returned fit ID and
+parameters unchanged in each donor run. In both modes, effect inference and
+Benjamini-Hochberg correction are independent within each donor.
+
+The donor-local route defaults to pseudocount 0 and creates result,
+``.dispersion.tsv``, ``.qc.tsv``, and ``.provenance.json`` artifacts without
+overwriting existing files. ``--expected-manifest-sha256`` can pin the locked
+bundle manifest to an external digest. Standalone legacy tables may use
+``sample`` instead of ``donor_id``; a locked bundle may not, and a table with
+both columns is rejected.
+
 Single-Cell Analysis
 --------------------
 
@@ -81,7 +116,8 @@ Notes
 Defaults and contracts
 ----------------------
 
-- ``pseudocount`` defaults to **1** (added to both ``ref_count`` and
+- ``pseudocount`` defaults to **1** on the legacy route and **0** with
+  ``--scope per-donor``. On the legacy route it is added to both ``ref_count`` and
   ``alt_count`` — Laplace-style shrinkage toward :math:`\mu = 0.5`,
   conservative under :math:`H_0`).
 - ``min_count`` defaults to **10**; regions with :math:`N < 10` are dropped.

--- a/rust/src/analysis.rs
+++ b/rust/src/analysis.rs
@@ -968,6 +968,7 @@ pub fn fdr_correction(pvals: &[f64]) -> Vec<f64> {
 /// Single dispersion model analysis
 ///
 /// Python equivalent: `single_model()` in as_analysis.py
+#[allow(dead_code)]
 fn single_model_with_dispersion(
     variants: Vec<VariantCounts>,
     phased: bool,
@@ -986,6 +987,7 @@ fn single_model_with_dispersion(
     Ok((results, disp))
 }
 
+#[allow(dead_code)]
 pub fn single_model(variants: Vec<VariantCounts>, phased: bool) -> Result<Vec<ImbalanceResult>> {
     Ok(single_model_with_dispersion(variants, phased)?.0)
 }
@@ -994,6 +996,7 @@ pub fn single_model(variants: Vec<VariantCounts>, phased: bool) -> Result<Vec<Im
 ///
 /// Python equivalent: `linear_model()` in as_analysis.py
 /// Uses standardized raw depth for the globally optimized linear predictor.
+#[allow(dead_code)]
 pub fn linear_model_with_dispersion(
     variants: Vec<VariantCounts>,
     phased: bool,
@@ -1012,6 +1015,7 @@ pub fn linear_model_with_dispersion(
     Ok((results, d1, d2))
 }
 
+#[allow(dead_code)]
 pub fn linear_model(variants: Vec<VariantCounts>, phased: bool) -> Result<Vec<ImbalanceResult>> {
     Ok(linear_model_with_dispersion(variants, phased)?.0)
 }
@@ -1398,6 +1402,7 @@ pub fn analyze_imbalance_detailed(
     analyze_prepared(prepared, config, parameters, false)
 }
 
+#[allow(dead_code)]
 pub fn analyze_imbalance(
     variants: Vec<VariantCounts>,
     config: &AnalysisConfig,

--- a/rust/src/analysis.rs
+++ b/rust/src/analysis.rs
@@ -24,8 +24,6 @@ pub struct VariantCounts {
     pub ref_count: u32,
     pub alt_count: u32,
     pub region: String,
-    /// Donor/sample identifier; required only by the per_donor model.
-    pub sample: Option<String>,
     /// Genotype phase relative to the reference allele: 0 = ref|alt, 1 = alt|ref.
     /// `None` when genotypes are absent or unphased. Required by phased analysis.
     pub gt: Option<u8>,
@@ -60,6 +58,16 @@ pub struct ImbalanceResult {
     pub fdr_pval: f64, // FDR-corrected p-value
 }
 
+/// Results and fitted nuisance parameters from one independent analysis table.
+#[derive(Debug, Clone)]
+pub struct AnalysisOutput {
+    pub results: Vec<ImbalanceResult>,
+    pub rho: Option<f64>,
+    pub linear_params: Option<(f64, f64)>,
+    pub n_observations: usize,
+    pub effective_phased: bool,
+}
+
 /// Configuration for analysis
 #[derive(Debug, Clone)]
 pub struct AnalysisConfig {
@@ -71,9 +79,71 @@ pub struct AnalysisConfig {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AnalysisMethod {
-    Single,   // Single global dispersion parameter
-    Linear,   // Linear dispersion model: rho = expit(d1 + N*d2)
-    PerDonor, // Per-donor dispersion: rho fit separately per sample
+    Single, // Single global dispersion parameter
+    Linear, // Linear dispersion model: rho = expit(d1 + N*d2)
+}
+
+/// Nuisance parameters fitted under the balanced beta-binomial null.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum DispersionParameters {
+    Single { rho: f64 },
+    Linear { d1: f64, d2: f64 },
+}
+
+impl DispersionParameters {
+    fn validate_for(self, method: AnalysisMethod) -> Result<Self> {
+        match (method, self) {
+            (AnalysisMethod::Single, Self::Single { rho }) => {
+                if !rho.is_finite() || !(0.0..=1.0).contains(&rho) {
+                    anyhow::bail!("fixed scalar rho must be finite and in [0, 1]");
+                }
+            }
+            (AnalysisMethod::Linear, Self::Linear { d1, d2 }) => {
+                if !d1.is_finite() || !d2.is_finite() {
+                    anyhow::bail!("fixed linear dispersion parameters must be finite");
+                }
+            }
+            (AnalysisMethod::Single, Self::Linear { .. }) => {
+                anyhow::bail!("method 'single' requires a fixed scalar rho");
+            }
+            (AnalysisMethod::Linear, Self::Single { .. }) => {
+                anyhow::bail!("method 'linear' requires fixed linear_d1 and linear_d2");
+            }
+        }
+        Ok(self)
+    }
+
+    #[inline]
+    fn rho_at_depth(self, n: u32) -> f64 {
+        match self {
+            Self::Single { rho } => clamp_rho(rho),
+            Self::Linear { d1, d2 } => {
+                let exp_in = (d1 + n as f64 * d2).clamp(-10.0, 10.0);
+                clamp_rho(expit(exp_in))
+            }
+        }
+    }
+
+    pub fn rho(self) -> Option<f64> {
+        match self {
+            Self::Single { rho } => Some(rho),
+            Self::Linear { .. } => None,
+        }
+    }
+
+    pub fn linear_params(self) -> Option<(f64, f64)> {
+        match self {
+            Self::Single { .. } => None,
+            Self::Linear { d1, d2 } => Some((d1, d2)),
+        }
+    }
+}
+
+/// Result of nuisance-only fitting on one independent table.
+#[derive(Debug, Clone, Copy)]
+pub struct DispersionFit {
+    pub parameters: DispersionParameters,
+    pub n_observations: usize,
 }
 
 impl Default for AnalysisConfig {
@@ -246,9 +316,10 @@ fn optimize_dispersion(ref_counts: &[u32], n_array: &[u32]) -> Result<f64> {
         }
     };
 
-    // Use golden section search (simple but effective)
-    let result = golden_section_search(objective, 0.001, 0.999, 1e-6)?;
-    Ok(result)
+    // Match scipy.optimize.minimize_scalar(method="bounded") used by AHO.
+    // In sparse donors the MLE can be far below 0.001, so imposing a floor
+    // changes the null likelihood and every downstream p-value.
+    scipy_bounded_minimize(objective, 0.0, 1.0, 1e-5, 500)
 }
 
 /// Optimize linear dispersion parameters using Nelder-Mead
@@ -404,9 +475,9 @@ fn optimize_prob_phased(
 ///
 /// Python equivalent: `opt_unphased_dp()` in as_analysis.py
 ///
-/// This marginalizes over unknown phase using dynamic programming. At each
-/// position after the first, we consider both phase possibilities and weight
-/// them equally (0.5 each), accumulating likelihood across the region.
+/// This marginalizes over unknown phase independently at every position. Both
+/// orientations receive equal prior weight, including the first SNP, so the
+/// feature likelihood does not depend on input row order.
 ///
 /// # Arguments
 /// * `prob` - Probability parameter (0 to 1)
@@ -427,6 +498,10 @@ pub fn optimize_prob_unphased_dp(
     phase_ref: &[u32],
     phase_n: &[u32],
 ) -> Result<f64> {
+    if disp.is_empty() {
+        anyhow::bail!("at least one dispersion value is required");
+    }
+
     // Split per-variant dispersion for first vs subsequent positions (linear model)
     let (first_disp, phase_disp): (f64, &[f64]) = if disp.len() > 1 {
         (disp[0], &disp[1..])
@@ -435,53 +510,38 @@ pub fn optimize_prob_unphased_dp(
         (disp[0], disp)
     };
 
-    // Get likelihood of first position (negative log-likelihood)
-    let first_ll = opt_prob(prob, first_disp, first_ref, first_n)?;
-
-    // If no subsequent positions, just return first_ll
-    if phase_ref.is_empty() {
-        return Ok(first_ll);
-    }
-
-    // Accumulate likelihoods for subsequent positions under both phase hypotheses
-    // in LOG-space (mathematically identical to the old linear product, but without
-    // underflow). For each position:
+    // Accumulate every position under both orientation hypotheses in log-space.
+    // For each SNP:
     //   log(0.5 * p1 + 0.5 * p2) = ln(0.5) + logaddexp(ln(p1), ln(p2))
-    // where lp1 = ln-pmf with prob and lp2 = ln-pmf with (1 - prob).
-    let mut log_prev: f64 = 0.0;
-
-    for (i, (&ref_count, &n)) in phase_ref.iter().zip(phase_n.iter()).enumerate() {
-        // Get dispersion for this position
-        let rho = if phase_disp.len() > 1 {
-            clamp_rho(phase_disp[i.min(phase_disp.len() - 1)])
-        } else {
-            clamp_rho(phase_disp[0])
-        };
-
-        // Phase 1: use prob
+    let orientation_log_likelihood = |ref_count: u32, n: u32, rho: f64| -> Result<f64> {
+        let rho = clamp_rho(rho);
         let alpha1 = prob * (1.0 - rho) / rho;
         let beta1 = (1.0 - prob) * (1.0 - rho) / rho;
         let bb1 = BetaBinomial::new(n, alpha1, beta1)
-            .context("Failed to create beta-binomial for phase1")?;
-        let lp1 = bb1.ln_f(&(ref_count as u64)); // log-pmf
+            .context("Failed to create beta-binomial for orientation 1")?;
+        let lp1 = bb1.ln_f(&(ref_count as u64));
 
-        // Phase 2: use (1 - prob)
-        let alpha2 = (1.0 - prob) * (1.0 - rho) / rho;
-        let beta2 = prob * (1.0 - rho) / rho;
-        let bb2 = BetaBinomial::new(n, alpha2, beta2)
-            .context("Failed to create beta-binomial for phase2")?;
-        let lp2 = bb2.ln_f(&(ref_count as u64)); // log-pmf
+        let bb2 = BetaBinomial::new(n, beta1, alpha1)
+            .context("Failed to create beta-binomial for orientation 2")?;
+        let lp2 = bb2.ln_f(&(ref_count as u64));
+        Ok((0.5_f64).ln() + logaddexp(lp1, lp2))
+    };
 
-        // DP update in log-space: marginalize over both phases with equal weight.
-        log_prev += (0.5_f64).ln() + logaddexp(lp1, lp2);
+    let mut log_likelihood = orientation_log_likelihood(first_ref, first_n, first_disp)?;
+
+    for (i, (&ref_count, &n)) in phase_ref.iter().zip(phase_n.iter()).enumerate() {
+        let rho = if phase_disp.len() > 1 {
+            phase_disp[i.min(phase_disp.len() - 1)]
+        } else {
+            phase_disp[0]
+        };
+        log_likelihood += orientation_log_likelihood(ref_count, n, rho)?;
     }
 
-    // Return first_ll + (-log_prev)
-    if !log_prev.is_finite() {
+    if !log_likelihood.is_finite() {
         return Ok(f64::INFINITY);
     }
-
-    Ok(first_ll + (-log_prev))
+    Ok(-log_likelihood)
 }
 
 /// Numerically stable two-argument log-sum-exp: ln(exp(a) + exp(b)).
@@ -497,6 +557,134 @@ fn logaddexp(a: f64, b: f64) -> f64 {
     } else {
         m + ((a - m).exp() + (b - m).exp()).ln()
     }
+}
+
+/// Exact two-sided beta-binomial p-value under the balanced null.
+///
+/// Outcomes at least as far from `n / 2` as the observed reference count are
+/// included. Summation and normalization are performed in log-space so fitted
+/// rho values close to the binomial boundary remain usable.
+pub fn exact_beta_binomial_pvalue(k: u32, n: u32, rho: f64) -> Result<f64> {
+    if k > n {
+        anyhow::bail!("reference count cannot exceed total count");
+    }
+
+    let rho = clamp_rho(rho);
+    let alpha = 0.5 * (1.0 - rho) / rho;
+    let distribution = BetaBinomial::new(n, alpha, alpha)
+        .context("Failed to create beta-binomial for exact SNV test")?;
+    let observed_deviation = (2_i64 * k as i64 - n as i64).abs();
+    let mut log_total = f64::NEG_INFINITY;
+    let mut log_tail = f64::NEG_INFINITY;
+
+    for outcome in 0..=n {
+        let log_pmf = distribution.ln_f(&(outcome as u64));
+        log_total = logaddexp(log_total, log_pmf);
+        let deviation = (2_i64 * outcome as i64 - n as i64).abs();
+        if deviation >= observed_deviation {
+            log_tail = logaddexp(log_tail, log_pmf);
+        }
+    }
+
+    if !log_total.is_finite() || !log_tail.is_finite() {
+        anyhow::bail!("exact beta-binomial p-value was non-finite");
+    }
+    Ok((log_tail - log_total).exp().clamp(0.0, 1.0))
+}
+
+/// Bounded Brent minimizer matching SciPy's default scalar-bounded routine.
+fn scipy_bounded_minimize<F>(f: F, x1: f64, x2: f64, xatol: f64, maxfun: usize) -> Result<f64>
+where
+    F: Fn(f64) -> f64,
+{
+    if !x1.is_finite() || !x2.is_finite() || x1 > x2 {
+        anyhow::bail!("invalid bounded optimization interval");
+    }
+    let sqrt_eps = (2.2e-16_f64).sqrt();
+    let golden_mean = 0.5 * (3.0 - 5.0_f64.sqrt());
+    let (mut a, mut b) = (x1, x2);
+    let mut fulc = a + golden_mean * (b - a);
+    let (mut nfc, mut xf) = (fulc, fulc);
+    let (mut rat, mut e) = (0.0_f64, 0.0_f64);
+    let mut fx = f(xf);
+    let (mut ffulc, mut fnfc) = (fx, fx);
+    let mut fu = f64::INFINITY;
+    let mut calls = 1_usize;
+    let mut xm = 0.5 * (a + b);
+    let mut tol1 = sqrt_eps * xf.abs() + xatol / 3.0;
+    let mut tol2 = 2.0 * tol1;
+
+    while (xf - xm).abs() > tol2 - 0.5 * (b - a) {
+        let mut golden = true;
+        if e.abs() > tol1 {
+            let r = (xf - nfc) * (fx - ffulc);
+            let q0 = (xf - fulc) * (fx - fnfc);
+            let mut p = (xf - fulc) * q0 - (xf - nfc) * r;
+            let mut q = 2.0 * (q0 - r);
+            if q > 0.0 {
+                p = -p;
+            }
+            q = q.abs();
+            let previous_e = e;
+            e = rat;
+            if p.abs() < (0.5 * q * previous_e).abs() && p > q * (a - xf) && p < q * (b - xf) {
+                rat = p / q;
+                let candidate = xf + rat;
+                if candidate - a < tol2 || b - candidate < tol2 {
+                    rat = tol1 * if xm - xf >= 0.0 { 1.0 } else { -1.0 };
+                }
+                golden = false;
+            }
+        }
+        if golden {
+            e = if xf >= xm { a - xf } else { b - xf };
+            rat = golden_mean * e;
+        }
+
+        let direction = if rat >= 0.0 { 1.0 } else { -1.0 };
+        let x = xf + direction * rat.abs().max(tol1);
+        fu = f(x);
+        calls += 1;
+        if fu <= fx {
+            if x >= xf {
+                a = xf;
+            } else {
+                b = xf;
+            }
+            fulc = nfc;
+            ffulc = fnfc;
+            nfc = xf;
+            fnfc = fx;
+            xf = x;
+            fx = fu;
+        } else {
+            if x < xf {
+                a = x;
+            } else {
+                b = x;
+            }
+            if fu <= fnfc || nfc == xf {
+                fulc = nfc;
+                ffulc = fnfc;
+                nfc = x;
+                fnfc = fu;
+            } else if fu <= ffulc || fulc == xf || fulc == nfc {
+                fulc = x;
+                ffulc = fu;
+            }
+        }
+
+        xm = 0.5 * (a + b);
+        tol1 = sqrt_eps * xf.abs() + xatol / 3.0;
+        tol2 = 2.0 * tol1;
+        if calls >= maxfun {
+            anyhow::bail!("bounded scalar optimization exceeded {maxfun} evaluations");
+        }
+    }
+    if !xf.is_finite() || !fx.is_finite() || fu.is_nan() {
+        anyhow::bail!("bounded scalar optimization produced a non-finite result");
+    }
+    Ok(xf)
 }
 
 /// Golden section search for 1D optimization
@@ -690,160 +878,117 @@ pub fn fdr_correction(pvals: &[f64]) -> Vec<f64> {
 /// Single dispersion model analysis
 ///
 /// Python equivalent: `single_model()` in as_analysis.py
-pub fn single_model(variants: Vec<VariantCounts>, phased: bool) -> Result<Vec<ImbalanceResult>> {
+fn single_model_with_dispersion(
+    variants: Vec<VariantCounts>,
+    phased: bool,
+) -> Result<(Vec<ImbalanceResult>, f64)> {
     if variants.is_empty() {
-        return Ok(vec![]);
+        return Ok((vec![], f64::NAN));
     }
 
-    // Extract ref_counts and N for all variants
-    let ref_counts: Vec<u32> = variants.iter().map(|v| v.ref_count).collect();
-    let n_array: Vec<u32> = variants.iter().map(|v| v.ref_count + v.alt_count).collect();
-
-    // Step 1: Optimize global dispersion parameter
     eprintln!("Optimizing dispersion parameter...");
-    let disp = optimize_dispersion(&ref_counts, &n_array)?;
+    let parameters = fit_dispersion_parameters(&variants, AnalysisMethod::Single)?;
+    let DispersionParameters::Single { rho: disp } = parameters else {
+        unreachable!("single fit returned linear parameters")
+    };
     eprintln!("  Dispersion: {:.6}", disp);
+    let results = test_fixed_dispersion(variants, phased, parameters, false, 0)?;
+    Ok((results, disp))
+}
 
-    // Step 2: Group by region
-    let mut region_map: HashMap<String, Vec<usize>> = HashMap::new();
-    for (i, variant) in variants.iter().enumerate() {
-        region_map
-            .entry(variant.region.clone())
-            .or_default()
-            .push(i);
-    }
-
-    eprintln!(
-        "Optimizing imbalance likelihood for {} regions...",
-        region_map.len()
-    );
-
-    // Step 3: Calculate null and alternative likelihoods per region (parallel)
-    // Clamp disp before calculating null_param (Issue #228)
-    let disp = clamp_rho(disp);
-    let null_param = 0.5 * (1.0 - disp) / disp;
-
-    let results: Result<Vec<_>> = region_map
-        .par_iter()
-        .map(|(region, indices)| -> Result<ImbalanceResult> {
-            // Extract counts for this region
-            let region_ref: Vec<u32> = indices.iter().map(|&i| ref_counts[i]).collect();
-            let region_n: Vec<u32> = indices.iter().map(|&i| n_array[i]).collect();
-
-            // Null model: prob = 0.5 (no imbalance)
-            let null_ll = betabinom_logpmf_sum(&region_ref, &region_n, null_param, null_param)?;
-
-            // Alternative model: optimize prob (phase-aware routing)
-            let all_gt = indices.iter().all(|&i| variants[i].gt.is_some());
-            let (alt_ll, mu) = if phased && indices.len() > 1 && all_gt {
-                // Phased multi-SNP region: use known genotype phase.
-                let region_gt: Vec<u8> = indices
-                    .iter()
-                    .map(|&i| variants[i].gt.expect("gt present (checked by all_gt)"))
-                    .collect();
-                // single_model uses one global scalar dispersion; pass it as a
-                // 1-element slice so the broadcast fallback keeps results identical.
-                optimize_prob_phased(&region_ref, &region_n, &region_gt, &[disp])?
-            } else if indices.len() > 1 {
-                // Unphased multi-SNP region: marginalize over phase via DP,
-                // minimizing opt_unphased_dp over prob in (0, 1)
-                // (first = index 0, phase = remaining), matching Python's
-                // parse_opt() unphased branch (minimize_scalar(opt_unphased_dp,...)).
-                let disp_slice = [disp];
-                let first_ref = region_ref[0];
-                let first_n = region_n[0];
-                let phase_ref = &region_ref[1..];
-                let phase_n = &region_n[1..];
-                let objective = |prob: f64| -> f64 {
-                    optimize_prob_unphased_dp(
-                        prob,
-                        &disp_slice,
-                        first_ref,
-                        first_n,
-                        phase_ref,
-                        phase_n,
-                    )
-                    .unwrap_or(f64::INFINITY)
-                };
-                let mu = golden_section_search(objective, 0.0, 1.0, 1e-6)?;
-                let alt_ll = -objective(mu);
-                (alt_ll, mu)
-            } else {
-                optimize_prob(&region_ref, &region_n, disp)?
-            };
-
-            // Likelihood ratio test
-            let lrt = -2.0 * (null_ll - alt_ll);
-
-            // P-value from chi-squared distribution (df=1)
-            let chi2 = ChiSquared::new(1.0).context("Failed to create chi-squared distribution")?;
-            let pval = 1.0 - chi2.cdf(lrt);
-
-            // Sum counts for this region
-            let total_ref: u32 = region_ref.iter().sum();
-            let total_alt: u32 = indices.iter().map(|&i| variants[i].alt_count).sum();
-            let total_n = total_ref + total_alt;
-
-            Ok(ImbalanceResult {
-                region: region.clone(),
-                ref_count: total_ref,
-                alt_count: total_alt,
-                n: total_n,
-                snp_count: indices.len(),
-                null_ll,
-                alt_ll,
-                mu,
-                lrt,
-                pval,
-                fdr_pval: 0.0, // Will be filled later
-            })
-        })
-        .collect();
-
-    let mut results = results?;
-
-    // Sort by region name for deterministic output across runs
-    results.sort_by(|a, b| a.region.cmp(&b.region));
-
-    // Step 4: FDR correction
-    let pvals: Vec<f64> = results.iter().map(|r| r.pval).collect();
-    let fdr_pvals = fdr_correction(&pvals);
-
-    for (result, fdr_pval) in results.iter_mut().zip(fdr_pvals.iter()) {
-        result.fdr_pval = *fdr_pval;
-    }
-
-    Ok(results)
+pub fn single_model(variants: Vec<VariantCounts>, phased: bool) -> Result<Vec<ImbalanceResult>> {
+    Ok(single_model_with_dispersion(variants, phased)?.0)
 }
 
 /// Linear dispersion model analysis
 ///
 /// Python equivalent: `linear_model()` in as_analysis.py
 /// Uses ρ = expit(d1 + N × d2) where d1, d2 are globally optimized parameters.
+pub fn linear_model_with_dispersion(
+    variants: Vec<VariantCounts>,
+    phased: bool,
+) -> Result<(Vec<ImbalanceResult>, f64, f64)> {
+    if variants.is_empty() {
+        return Ok((vec![], f64::NAN, f64::NAN));
+    }
+
+    eprintln!("Optimizing linear dispersion parameters...");
+    let parameters = fit_dispersion_parameters(&variants, AnalysisMethod::Linear)?;
+    let DispersionParameters::Linear { d1, d2 } = parameters else {
+        unreachable!("linear fit returned scalar parameters")
+    };
+    eprintln!("  d1 = {:.6}, d2 = {:.6}", d1, d2);
+    let results = test_fixed_dispersion(variants, phased, parameters, false, 0)?;
+    Ok((results, d1, d2))
+}
+
 pub fn linear_model(variants: Vec<VariantCounts>, phased: bool) -> Result<Vec<ImbalanceResult>> {
+    Ok(linear_model_with_dispersion(variants, phased)?.0)
+}
+
+fn fit_dispersion_parameters(
+    variants: &[VariantCounts],
+    method: AnalysisMethod,
+) -> Result<DispersionParameters> {
+    if variants.is_empty() {
+        anyhow::bail!("cannot fit dispersion without observations");
+    }
+
+    let ref_counts: Vec<u32> = variants.iter().map(|variant| variant.ref_count).collect();
+    let n_array: Vec<u32> = variants
+        .iter()
+        .map(|variant| variant.ref_count + variant.alt_count)
+        .collect();
+    match method {
+        AnalysisMethod::Single => Ok(DispersionParameters::Single {
+            rho: optimize_dispersion(&ref_counts, &n_array)?,
+        }),
+        AnalysisMethod::Linear => {
+            let (d1, d2) = optimize_dispersion_linear(&ref_counts, &n_array)?;
+            Ok(DispersionParameters::Linear { d1, d2 })
+        }
+    }
+}
+
+fn canonicalize_region_indices(
+    region_map: &mut HashMap<String, Vec<usize>>,
+    variants: &[VariantCounts],
+) {
+    for indices in region_map.values_mut() {
+        indices.sort_unstable_by(|left, right| {
+            let left = &variants[*left];
+            let right = &variants[*right];
+            left.chrom
+                .cmp(&right.chrom)
+                .then_with(|| left.pos.cmp(&right.pos))
+                .then_with(|| left.ref_count.cmp(&right.ref_count))
+                .then_with(|| left.alt_count.cmp(&right.alt_count))
+                .then_with(|| left.gt.cmp(&right.gt))
+        });
+    }
+}
+
+fn test_fixed_dispersion(
+    variants: Vec<VariantCounts>,
+    phased: bool,
+    parameters: DispersionParameters,
+    exact_snv_pvalues: bool,
+    pseudocount: u32,
+) -> Result<Vec<ImbalanceResult>> {
     if variants.is_empty() {
         return Ok(vec![]);
     }
 
-    // Extract ref_counts and N for all variants
-    let ref_counts: Vec<u32> = variants.iter().map(|v| v.ref_count).collect();
-    let n_array: Vec<u32> = variants.iter().map(|v| v.ref_count + v.alt_count).collect();
-
-    // Step 1: Optimize linear dispersion parameters (d1, d2)
-    eprintln!("Optimizing linear dispersion parameters...");
-    let (d1, d2) = optimize_dispersion_linear(&ref_counts, &n_array)?;
-    eprintln!("  d1 = {:.6}, d2 = {:.6}", d1, d2);
-
-    // Step 2: Compute per-variant rho array
+    let ref_counts: Vec<u32> = variants.iter().map(|variant| variant.ref_count).collect();
+    let n_array: Vec<u32> = variants
+        .iter()
+        .map(|variant| variant.ref_count + variant.alt_count)
+        .collect();
     let rho_array: Vec<f64> = n_array
         .iter()
-        .map(|&n| {
-            let exp_in = (d1 + n as f64 * d2).clamp(-10.0, 10.0);
-            clamp_rho(expit(exp_in))
-        })
+        .map(|&n| parameters.rho_at_depth(n))
         .collect();
 
-    // Step 3: Group by region
     let mut region_map: HashMap<String, Vec<usize>> = HashMap::new();
     for (i, variant) in variants.iter().enumerate() {
         region_map
@@ -851,22 +996,20 @@ pub fn linear_model(variants: Vec<VariantCounts>, phased: bool) -> Result<Vec<Im
             .or_default()
             .push(i);
     }
+    canonicalize_region_indices(&mut region_map, &variants);
 
     eprintln!(
         "Optimizing imbalance likelihood for {} regions...",
         region_map.len()
     );
 
-    // Step 4: Calculate null and alternative likelihoods per region (parallel)
     let results: Result<Vec<_>> = region_map
         .par_iter()
         .map(|(region, indices)| -> Result<ImbalanceResult> {
-            // Extract counts and rho for this region
             let region_ref: Vec<u32> = indices.iter().map(|&i| ref_counts[i]).collect();
             let region_n: Vec<u32> = indices.iter().map(|&i| n_array[i]).collect();
             let region_rho: Vec<f64> = indices.iter().map(|&i| rho_array[i]).collect();
 
-            // Null model: prob = 0.5, using per-variant rho
             let mut null_ll = 0.0;
             for ((&ref_count, &n), &rho) in region_ref
                 .iter()
@@ -880,26 +1023,14 @@ pub fn linear_model(variants: Vec<VariantCounts>, phased: bool) -> Result<Vec<Im
                 null_ll += bb.ln_f(&(ref_count as u64));
             }
 
-            // Alternative model: optimize prob using the per-SNP rho slice
-            // (region_rho), which is aligned 1:1 with region_ref/region_n in the
-            // region's index order ([0] = first SNP, [1..] = subsequent SNPs).
-            // This matches Python's per-row df["disp"] and intentionally differs
-            // from single_model's single global scalar dispersion.
             let all_gt = indices.iter().all(|&i| variants[i].gt.is_some());
             let (alt_ll, mu) = if phased && indices.len() > 1 && all_gt {
-                // Phased multi-SNP region: use known genotype phase.
                 let region_gt: Vec<u8> = indices
                     .iter()
                     .map(|&i| variants[i].gt.expect("gt present (checked by all_gt)"))
                     .collect();
                 optimize_prob_phased(&region_ref, &region_n, &region_gt, &region_rho)?
             } else if indices.len() > 1 {
-                // Unphased multi-SNP region: marginalize over phase via DP,
-                // minimizing opt_unphased_dp over prob in (0, 1)
-                // (first = index 0, phase = remaining), matching Python's
-                // parse_opt() unphased branch (minimize_scalar(opt_unphased_dp,...)).
-                // region_rho is in the region's index order ([0] = first,
-                // [1..] = phase), matching opt_unphased_dp's internal split.
                 let first_ref = region_ref[0];
                 let first_n = region_n[0];
                 let phase_ref = &region_ref[1..];
@@ -915,213 +1046,31 @@ pub fn linear_model(variants: Vec<VariantCounts>, phased: bool) -> Result<Vec<Im
                     )
                     .unwrap_or(f64::INFINITY)
                 };
-                let mu = golden_section_search(objective, 0.0, 1.0, 1e-6)?;
+                // The orientation-marginal likelihood is symmetric around 0.5.
+                // Restrict to one half to make the reported magnitude identifiable.
+                let mu = golden_section_search(objective, 0.5, 1.0, 1e-6)?;
                 let alt_ll = -objective(mu);
                 (alt_ll, mu)
             } else {
                 optimize_prob(&region_ref, &region_n, region_rho[0])?
             };
 
-            // Likelihood ratio test (clamped at 0 to avoid tiny negative LRT from
-            // optimizer noise; matches Python's chi2.sf behavior on near-zero LRT)
             let lrt = (-2.0 * (null_ll - alt_ll)).max(0.0);
-
-            // P-value from chi-squared distribution (df=1)
-            let chi2 = ChiSquared::new(1.0).context("Failed to create chi-squared distribution")?;
-            let pval = 1.0 - chi2.cdf(lrt);
-
-            // Sum counts for this region
-            let total_ref: u32 = region_ref.iter().sum();
-            let total_alt: u32 = indices.iter().map(|&i| variants[i].alt_count).sum();
-            let total_n = total_ref + total_alt;
-
-            Ok(ImbalanceResult {
-                region: region.clone(),
-                ref_count: total_ref,
-                alt_count: total_alt,
-                n: total_n,
-                snp_count: indices.len(),
-                null_ll,
-                alt_ll,
-                mu,
-                lrt,
-                pval,
-                fdr_pval: 0.0,
-            })
-        })
-        .collect();
-
-    let mut results = results?;
-
-    // Step 5: FDR correction
-    let pvals: Vec<f64> = results.iter().map(|r| r.pval).collect();
-    let fdr_pvals = fdr_correction(&pvals);
-
-    for (result, fdr_pval) in results.iter_mut().zip(fdr_pvals.iter()) {
-        result.fdr_pval = *fdr_pval;
-    }
-
-    Ok(results)
-}
-
-/// Fit per-donor dispersion (rho) via bounded MLE, one value per `sample`.
-///
-/// Python equivalent: `compute_per_donor_rho()` — each donor's rho is the
-/// symmetric beta-binomial MLE over all that donor's observations, bounded to
-/// (1e-6, 1-1e-6). No extra floor (matches locked donor_rho.tsv: min ~7e-6).
-fn compute_donor_rho(variants: &[VariantCounts]) -> Result<HashMap<String, f64>> {
-    // Group observation indices by donor
-    let mut donor_map: HashMap<String, Vec<usize>> = HashMap::new();
-    for (i, v) in variants.iter().enumerate() {
-        let donor = v.sample.clone().ok_or_else(|| {
-            anyhow::anyhow!("per_donor model requires a 'sample' column in the counts TSV")
-        })?;
-        donor_map.entry(donor).or_default().push(i);
-    }
-
-    // Fit rho per donor in parallel (golden-section on symmetric beta-binomial)
-    donor_map
-        .par_iter()
-        .map(|(donor, idx)| -> Result<(String, f64)> {
-            let dref: Vec<u32> = idx.iter().map(|&i| variants[i].ref_count).collect();
-            let dn: Vec<u32> = idx
-                .iter()
-                .map(|&i| variants[i].ref_count + variants[i].alt_count)
-                .collect();
-            let objective = |rho: f64| -> f64 {
-                let rho = clamp_rho(rho);
-                let a = 0.5 * (1.0 - rho) / rho;
-                match betabinom_logpmf_sum(&dref, &dn, a, a) {
-                    Ok(ll) => -ll,
-                    Err(_) => f64::INFINITY,
-                }
-            };
-            // Bounds (1e-6, 1-1e-6) match scipy minimize_scalar(method="bounded")
-            let rho = golden_section_search(objective, 1e-6, 1.0 - 1e-6, 1e-6)?;
-            Ok((donor.clone(), rho))
-        })
-        .collect()
-}
-
-/// Per-donor dispersion model analysis.
-///
-/// Python equivalent: WASP2 `per_donor` extension — fit rho per `sample`, then
-/// run the standard per-region beta-binomial LRT using each observation's
-/// donor-specific rho (per-observation rho in BOTH null and alternative).
-pub fn per_donor_model(variants: Vec<VariantCounts>, phased: bool) -> Result<Vec<ImbalanceResult>> {
-    if variants.is_empty() {
-        return Ok(vec![]);
-    }
-
-    // Step 1: fit per-donor dispersion
-    eprintln!("Fitting per-donor dispersion...");
-    let donor_rho = compute_donor_rho(&variants)?;
-    eprintln!("  Fit rho for {} donors", donor_rho.len());
-    // Emit fitted rho (for validation against locked donor_rho.tsv)
-    let mut donors_sorted: Vec<(&String, &f64)> = donor_rho.iter().collect();
-    donors_sorted.sort_by(|a, b| a.0.cmp(b.0));
-    for (donor, rho) in donors_sorted {
-        eprintln!("DONOR_RHO\t{}\t{:.8}", donor, rho);
-    }
-
-    // Step 2: per-observation rho = each obs's donor rho
-    let ref_counts: Vec<u32> = variants.iter().map(|v| v.ref_count).collect();
-    let n_array: Vec<u32> = variants.iter().map(|v| v.ref_count + v.alt_count).collect();
-    let rho_array: Vec<f64> = variants
-        .iter()
-        .map(|v| {
-            let donor = v
-                .sample
-                .as_ref()
-                .expect("sample present (checked in compute_donor_rho)");
-            clamp_rho(
-                *donor_rho
-                    .get(donor)
-                    .expect("donor rho fit for every sample"),
-            )
-        })
-        .collect();
-
-    // Step 3: group by region
-    let mut region_map: HashMap<String, Vec<usize>> = HashMap::new();
-    for (i, variant) in variants.iter().enumerate() {
-        region_map
-            .entry(variant.region.clone())
-            .or_default()
-            .push(i);
-    }
-    eprintln!(
-        "Optimizing imbalance likelihood for {} regions...",
-        region_map.len()
-    );
-
-    // Step 4: per-region null/alt LL + LRT, using per-observation rho
-    let results: Result<Vec<_>> = region_map
-        .par_iter()
-        .map(|(region, indices)| -> Result<ImbalanceResult> {
-            let region_ref: Vec<u32> = indices.iter().map(|&i| ref_counts[i]).collect();
-            let region_n: Vec<u32> = indices.iter().map(|&i| n_array[i]).collect();
-            let region_rho: Vec<f64> = indices.iter().map(|&i| rho_array[i]).collect();
-
-            use rv::traits::HasDensity;
-
-            // Null model: prob = 0.5, per-observation rho
-            let mut null_ll = 0.0;
-            for ((&ref_count, &n), &rho) in region_ref
-                .iter()
-                .zip(region_n.iter())
-                .zip(region_rho.iter())
-            {
-                let alpha = 0.5 * (1.0 - rho) / rho;
-                let bb = rv::dist::BetaBinomial::new(n, alpha, alpha)
-                    .context("Failed to create beta-binomial for null")?;
-                null_ll += bb.ln_f(&(ref_count as u64));
-            }
-
-            // Alternative model: optimize one pi, per-observation rho.
-            // Phase-aware routing (mirrors single_model): for a phased multi-SNP
-            // region with known GT, use the haplotype-phased likelihood, feeding
-            // the per-observation (per-donor) rho slice into optimize_prob_phased's
-            // &[f64] disp argument. Otherwise (unphased, or single-SNP, or missing
-            // GT) use the unphased shared-pi product UNCHANGED — so phased=false is
-            // byte-identical to the pre-phasing per_donor model.
-            let all_gt = indices.iter().all(|&i| variants[i].gt.is_some());
-            let (alt_ll, mu) = if phased && indices.len() > 1 && all_gt {
-                let region_gt: Vec<u8> = indices
-                    .iter()
-                    .map(|&i| variants[i].gt.expect("gt present (checked by all_gt)"))
-                    .collect();
-                // Per-observation donor rho flows straight into the &[f64] slice.
-                optimize_prob_phased(&region_ref, &region_n, &region_gt, &region_rho)?
+            let pval = if exact_snv_pvalues && indices.len() == 1 {
+                let variant = &variants[indices[0]];
+                let raw_ref = variant.ref_count.checked_sub(pseudocount).ok_or_else(|| {
+                    anyhow::anyhow!("reference count is smaller than the pseudocount")
+                })?;
+                let raw_alt = variant.alt_count.checked_sub(pseudocount).ok_or_else(|| {
+                    anyhow::anyhow!("alternate count is smaller than the pseudocount")
+                })?;
+                let raw_n = raw_ref + raw_alt;
+                exact_beta_binomial_pvalue(raw_ref, raw_n, parameters.rho_at_depth(raw_n))?
             } else {
-                // Unphased: optimize one pi over the per-observation beta-binomial
-                // product (matches Python _alt_ll: a=pi(1-rho)/rho, b=(1-pi)(1-rho)/rho)
-                let alt_obj = |pi: f64| -> f64 {
-                    let pi = pi.clamp(1e-6, 1.0 - 1e-6);
-                    let mut nll = 0.0;
-                    for ((&ref_count, &n), &rho) in region_ref
-                        .iter()
-                        .zip(region_n.iter())
-                        .zip(region_rho.iter())
-                    {
-                        let a = pi * (1.0 - rho) / rho;
-                        let b = (1.0 - pi) * (1.0 - rho) / rho;
-                        match rv::dist::BetaBinomial::new(n, a, b) {
-                            Ok(bb) => nll -= bb.ln_f(&(ref_count as u64)),
-                            Err(_) => return f64::INFINITY,
-                        }
-                    }
-                    nll
-                };
-                let mu = golden_section_search(alt_obj, 1e-6, 1.0 - 1e-6, 1e-6)?;
-                let alt_ll = -alt_obj(mu);
-                (alt_ll, mu)
+                let chi2 =
+                    ChiSquared::new(1.0).context("Failed to create chi-squared distribution")?;
+                1.0 - chi2.cdf(lrt)
             };
-
-            // Likelihood ratio test (clamped at 0 like Python)
-            let lrt = (-2.0 * (null_ll - alt_ll)).max(0.0);
-            let chi2 = ChiSquared::new(1.0).context("Failed to create chi-squared distribution")?;
-            let pval = 1.0 - chi2.cdf(lrt);
 
             let total_ref: u32 = region_ref.iter().sum();
             let total_alt: u32 = indices.iter().map(|&i| variants[i].alt_count).sum();
@@ -1144,28 +1093,24 @@ pub fn per_donor_model(variants: Vec<VariantCounts>, phased: bool) -> Result<Vec
         .collect();
 
     let mut results = results?;
-
-    // Deterministic output order
-    results.sort_by(|a, b| a.region.cmp(&b.region));
-
-    // FDR correction (BH)
+    results.sort_by(|left, right| left.region.cmp(&right.region));
     let pvals: Vec<f64> = results.iter().map(|r| r.pval).collect();
     let fdr_pvals = fdr_correction(&pvals);
     for (result, fdr_pval) in results.iter_mut().zip(fdr_pvals.iter()) {
         result.fdr_pval = *fdr_pval;
     }
-
     Ok(results)
 }
 
 /// Main entry point for allelic imbalance analysis
 ///
 /// Python equivalent: `get_imbalance()` in as_analysis.py
-pub fn analyze_imbalance(
+struct PreparedAnalysis {
     variants: Vec<VariantCounts>,
-    config: &AnalysisConfig,
-) -> Result<Vec<ImbalanceResult>> {
-    // Apply filters and pseudocounts
+    effective_phased: bool,
+}
+
+fn prepare_analysis(variants: Vec<VariantCounts>, config: &AnalysisConfig) -> PreparedAnalysis {
     let filtered: Vec<VariantCounts> = variants
         .into_iter()
         .map(|mut v| {
@@ -1183,49 +1128,141 @@ pub fn analyze_imbalance(
 
     let phased = effective_phased(&filtered, config.phased);
 
-    // Deduplicate variants for Python parity (single and linear models only).
+    // Deduplicate variants for Python parity.
     // Python's get_imbalance() does: df[keep_cols].drop_duplicates()
-    // Per-donor model skips dedup as it's a Rust-only feature.
-    let deduped = if config.method != AnalysisMethod::PerDonor {
-        let before = filtered.len();
-        let after = deduplicate_variants(filtered, phased);
-        if after.len() < before {
-            eprintln!(
-                "Deduplicated {} → {} variants ({} duplicates removed)",
-                before,
-                after.len(),
-                before - after.len()
-            );
-        }
-        after
-    } else {
-        filtered
-    };
+    let before = filtered.len();
+    let deduped = deduplicate_variants(filtered, phased);
+    if deduped.len() < before {
+        eprintln!(
+            "Deduplicated {} → {} variants ({} duplicates removed)",
+            before,
+            deduped.len(),
+            before - deduped.len()
+        );
+    }
+    PreparedAnalysis {
+        variants: deduped,
+        effective_phased: phased,
+    }
+}
 
-    // Run analysis based on method
-    let mut results = match config.method {
-        AnalysisMethod::Single => single_model(deduped, phased)?,
-        AnalysisMethod::Linear => linear_model(deduped, phased)?,
-        AnalysisMethod::PerDonor => per_donor_model(deduped, phased)?,
-    };
-
-    // Remove pseudocounts from results
-    for result in results.iter_mut() {
-        if result.ref_count < config.pseudocount
-            || result.alt_count < config.pseudocount
-            || result.n < 2 * config.pseudocount
+fn remove_result_pseudocounts(results: &mut [ImbalanceResult], pseudocount: u32) {
+    for result in results {
+        let region_pseudocount = pseudocount.saturating_mul(result.snp_count as u32);
+        if result.ref_count < region_pseudocount
+            || result.alt_count < region_pseudocount
+            || result.n < 2 * region_pseudocount
         {
             eprintln!(
                 "[WARN] Counts smaller than pseudocount for region {}: ref={}, alt={}, n={}, pc={}",
-                result.region, result.ref_count, result.alt_count, result.n, config.pseudocount
+                result.region, result.ref_count, result.alt_count, result.n, region_pseudocount
             );
         }
-        result.ref_count = result.ref_count.saturating_sub(config.pseudocount);
-        result.alt_count = result.alt_count.saturating_sub(config.pseudocount);
-        result.n = result.n.saturating_sub(2 * config.pseudocount);
+        result.ref_count = result.ref_count.saturating_sub(region_pseudocount);
+        result.alt_count = result.alt_count.saturating_sub(region_pseudocount);
+        result.n = result.n.saturating_sub(2 * region_pseudocount);
+    }
+}
+
+fn analyze_prepared(
+    prepared: PreparedAnalysis,
+    config: &AnalysisConfig,
+    parameters: DispersionParameters,
+    exact_snv_pvalues: bool,
+) -> Result<AnalysisOutput> {
+    let n_observations = prepared.variants.len();
+    let mut results = test_fixed_dispersion(
+        prepared.variants,
+        prepared.effective_phased,
+        parameters,
+        exact_snv_pvalues,
+        config.pseudocount,
+    )?;
+    remove_result_pseudocounts(&mut results, config.pseudocount);
+
+    Ok(AnalysisOutput {
+        results,
+        rho: parameters.rho(),
+        linear_params: parameters.linear_params(),
+        n_observations,
+        effective_phased: prepared.effective_phased,
+    })
+}
+
+/// Fit only the balanced-null nuisance parameters for one independent table.
+pub fn fit_imbalance_dispersion(
+    variants: Vec<VariantCounts>,
+    config: &AnalysisConfig,
+) -> Result<DispersionFit> {
+    let prepared = prepare_analysis(variants, config);
+    if prepared.variants.is_empty() {
+        anyhow::bail!("no variants passed the count threshold for dispersion fitting");
     }
 
-    Ok(results)
+    match config.method {
+        AnalysisMethod::Single => eprintln!("Optimizing dispersion parameter..."),
+        AnalysisMethod::Linear => eprintln!("Optimizing linear dispersion parameters..."),
+    }
+    let parameters = fit_dispersion_parameters(&prepared.variants, config.method)?;
+    match parameters {
+        DispersionParameters::Single { rho } => eprintln!("  Dispersion: {:.6}", rho),
+        DispersionParameters::Linear { d1, d2 } => {
+            eprintln!("  d1 = {:.6}, d2 = {:.6}", d1, d2)
+        }
+    }
+    Ok(DispersionFit {
+        parameters,
+        n_observations: prepared.variants.len(),
+    })
+}
+
+/// Test effects with nuisance parameters supplied by a separate fitting run.
+pub fn analyze_imbalance_with_fixed_dispersion(
+    variants: Vec<VariantCounts>,
+    config: &AnalysisConfig,
+    parameters: DispersionParameters,
+    exact_snv_pvalues: bool,
+) -> Result<AnalysisOutput> {
+    let parameters = parameters.validate_for(config.method)?;
+    let prepared = prepare_analysis(variants, config);
+    analyze_prepared(prepared, config, parameters, exact_snv_pvalues)
+}
+
+pub fn analyze_imbalance_detailed(
+    variants: Vec<VariantCounts>,
+    config: &AnalysisConfig,
+) -> Result<AnalysisOutput> {
+    let prepared = prepare_analysis(variants, config);
+    let n_observations = prepared.variants.len();
+    if n_observations == 0 {
+        return Ok(AnalysisOutput {
+            results: vec![],
+            rho: None,
+            linear_params: None,
+            n_observations,
+            effective_phased: prepared.effective_phased,
+        });
+    }
+
+    match config.method {
+        AnalysisMethod::Single => eprintln!("Optimizing dispersion parameter..."),
+        AnalysisMethod::Linear => eprintln!("Optimizing linear dispersion parameters..."),
+    }
+    let parameters = fit_dispersion_parameters(&prepared.variants, config.method)?;
+    match parameters {
+        DispersionParameters::Single { rho } => eprintln!("  Dispersion: {:.6}", rho),
+        DispersionParameters::Linear { d1, d2 } => {
+            eprintln!("  d1 = {:.6}, d2 = {:.6}", d1, d2)
+        }
+    }
+    analyze_prepared(prepared, config, parameters, false)
+}
+
+pub fn analyze_imbalance(
+    variants: Vec<VariantCounts>,
+    config: &AnalysisConfig,
+) -> Result<Vec<ImbalanceResult>> {
+    Ok(analyze_imbalance_detailed(variants, config)?.results)
 }
 
 #[cfg(test)]
@@ -1305,6 +1342,14 @@ mod tests {
     }
 
     #[test]
+    fn test_scipy_bounded_minimize_preserves_near_zero_solution() {
+        let minimum = scipy_bounded_minimize(|rho| rho, 0.0, 1.0, 1e-5, 500).unwrap();
+        let scipy_boundary = 5.9608609865491405e-6;
+        assert!((minimum - scipy_boundary).abs() < 1e-15);
+        assert!(minimum < 0.001);
+    }
+
+    #[test]
     fn test_optimize_prob_unphased_dp_single_position() {
         // Test with only first position (no subsequent positions)
         let disp = vec![0.1];
@@ -1360,6 +1405,19 @@ mod tests {
         assert!(result_imbalanced.is_finite());
     }
 
+    #[test]
+    fn test_exact_beta_binomial_pvalue_is_symmetric_and_handles_low_rho() {
+        let left = exact_beta_binomial_pvalue(2, 10, 0.08).unwrap();
+        let right = exact_beta_binomial_pvalue(8, 10, 0.08).unwrap();
+        assert!((left - right).abs() < 1e-12);
+        assert!((exact_beta_binomial_pvalue(5, 10, 0.08).unwrap() - 1.0).abs() < 1e-12);
+
+        // At the clamp boundary this converges to the ordinary two-sided
+        // binomial probability for observing 0 or 10 successes.
+        let near_binomial = exact_beta_binomial_pvalue(0, 10, 0.0).unwrap();
+        assert!((near_binomial - 2.0 / 1024.0).abs() < 1e-7);
+    }
+
     fn vc_peak(pos: u32, rc: u32, ac: u32, gt: Option<u8>) -> VariantCounts {
         VariantCounts {
             chrom: "chr1".to_string(),
@@ -1367,7 +1425,6 @@ mod tests {
             ref_count: rc,
             alt_count: ac,
             region: "peak1".to_string(),
-            sample: Some("d1".to_string()),
             gt,
         }
     }
@@ -1431,69 +1488,109 @@ mod tests {
         assert_result_close(&phased[0], &unphased[0]);
     }
 
-    // Helper: a per_donor VariantCounts for one donor "d1".
-    fn vc_d1(pos: u32, rc: u32, ac: u32, gt: u8) -> VariantCounts {
-        VariantCounts {
-            chrom: "chr1".to_string(),
-            pos,
-            ref_count: rc,
-            alt_count: ac,
-            region: "peak1".to_string(),
-            sample: Some("d1".to_string()),
-            gt: Some(gt),
-        }
+    #[test]
+    fn test_multi_snp_output_removes_every_pseudocount() {
+        let variants = vec![vc_peak(100, 10, 5, None), vc_peak(200, 7, 8, None)];
+        let config = AnalysisConfig {
+            min_count: 0,
+            pseudocount: 1,
+            method: AnalysisMethod::Single,
+            phased: false,
+        };
+        let output = analyze_imbalance_detailed(variants, &config).unwrap();
+        assert_eq!(output.results.len(), 1);
+        let result = &output.results[0];
+        assert_eq!(result.snp_count, 2);
+        assert_eq!(result.ref_count, 17);
+        assert_eq!(result.alt_count, 13);
+        assert_eq!(result.n, 30);
     }
 
     #[test]
-    fn test_per_donor_phased_wiring() {
-        // Phased per_donor on a single-donor multi-SNP region must equal a DIRECT
-        // optimize_prob_phased call with that donor's fitted rho — proving
-        // region_rho / region_gt are wired into the phased likelihood correctly.
+    fn test_unphased_feature_is_permutation_invariant_with_linear_nuisance() {
         let variants = vec![
-            vc_d1(100, 18, 4, 0),
-            vc_d1(200, 5, 15, 1),
-            vc_d1(300, 12, 8, 0),
+            vc_peak(300, 17, 3, None),
+            vc_peak(100, 4, 16, None),
+            vc_peak(200, 13, 12, None),
         ];
+        let mut reversed = variants.clone();
+        reversed.reverse();
+        let config = AnalysisConfig {
+            min_count: 0,
+            pseudocount: 0,
+            method: AnalysisMethod::Linear,
+            phased: false,
+        };
+        let nuisance = DispersionParameters::Linear {
+            d1: -3.0,
+            d2: 0.025,
+        };
 
-        let rho_map = compute_donor_rho(&variants).unwrap();
-        let rho = clamp_rho(rho_map["d1"]);
-        let region_ref = vec![18u32, 5, 12];
-        let region_n = vec![22u32, 20, 20];
-        let region_gt = vec![0u8, 1, 0];
-        let region_rho = vec![rho, rho, rho];
-        let (exp_alt, exp_mu) =
-            optimize_prob_phased(&region_ref, &region_n, &region_gt, &region_rho).unwrap();
-
-        let res = per_donor_model(variants, true).unwrap();
-        assert_eq!(res.len(), 1);
-        assert!(
-            (res[0].alt_ll - exp_alt).abs() < 1e-9,
-            "phased per_donor alt_ll {} != direct optimize_prob_phased {}",
-            res[0].alt_ll,
-            exp_alt
-        );
-        assert!(
-            (res[0].mu - exp_mu).abs() < 1e-9,
-            "mu {} != {}",
-            res[0].mu,
-            exp_mu
-        );
-        assert!(res[0].lrt >= 0.0, "LRT must be clamped >= 0");
+        let forward =
+            analyze_imbalance_with_fixed_dispersion(variants, &config, nuisance, false).unwrap();
+        let backward =
+            analyze_imbalance_with_fixed_dispersion(reversed, &config, nuisance, false).unwrap();
+        assert_eq!(forward.results.len(), 1);
+        assert_eq!(backward.results.len(), 1);
+        assert_result_close(&forward.results[0], &backward.results[0]);
+        assert_eq!(forward.results[0].fdr_pval, backward.results[0].fdr_pval);
     }
 
     #[test]
-    fn test_per_donor_unphased_ignores_gt() {
-        // phased=false uses the shared-pi product, which does NOT use GT —
-        // flipping GT must leave the unphased result unchanged.
-        let a = vec![vc_d1(100, 18, 4, 0), vc_d1(200, 5, 15, 1)];
-        let b = vec![vc_d1(100, 18, 4, 1), vc_d1(200, 5, 15, 0)]; // GT flipped
-        let ra = per_donor_model(a, false).unwrap();
-        let rb = per_donor_model(b, false).unwrap();
-        assert!(
-            (ra[0].lrt - rb[0].lrt).abs() < 1e-12,
-            "unphased per_donor must ignore GT: {} vs {}",
-            ra[0].lrt,
-            rb[0].lrt
-        );
+    fn test_fixed_nuisance_exact_snv_uses_raw_counts() {
+        let variants = vec![vc_peak(100, 8, 2, None)];
+        let no_pseudocount = AnalysisConfig {
+            min_count: 0,
+            pseudocount: 0,
+            method: AnalysisMethod::Single,
+            phased: false,
+        };
+        let with_pseudocount = AnalysisConfig {
+            pseudocount: 3,
+            ..no_pseudocount.clone()
+        };
+        let nuisance = DispersionParameters::Single { rho: 0.04 };
+
+        let raw = analyze_imbalance_with_fixed_dispersion(
+            variants.clone(),
+            &no_pseudocount,
+            nuisance,
+            true,
+        )
+        .unwrap();
+        let padded =
+            analyze_imbalance_with_fixed_dispersion(variants, &with_pseudocount, nuisance, true)
+                .unwrap();
+        assert_eq!(raw.results[0].ref_count, 8);
+        assert_eq!(padded.results[0].ref_count, 8);
+        assert_eq!(raw.results[0].alt_count, 2);
+        assert_eq!(padded.results[0].alt_count, 2);
+        assert!((raw.results[0].pval - padded.results[0].pval).abs() < 1e-12);
+        assert_eq!(raw.rho, Some(0.04));
+        assert_eq!(padded.rho, Some(0.04));
+    }
+
+    #[test]
+    fn test_fixed_linear_nuisance_is_reported_without_refitting() {
+        let config = AnalysisConfig {
+            min_count: 0,
+            pseudocount: 0,
+            method: AnalysisMethod::Linear,
+            phased: false,
+        };
+        let nuisance = DispersionParameters::Linear {
+            d1: -4.25,
+            d2: 0.031,
+        };
+        let output = analyze_imbalance_with_fixed_dispersion(
+            vec![vc_peak(100, 7, 5, None)],
+            &config,
+            nuisance,
+            false,
+        )
+        .unwrap();
+        assert_eq!(output.linear_params, Some((-4.25, 0.031)));
+        assert_eq!(output.rho, None);
+        assert_eq!(output.n_observations, 1);
     }
 }

--- a/rust/src/analysis.rs
+++ b/rust/src/analysis.rs
@@ -64,6 +64,8 @@ pub struct AnalysisOutput {
     pub results: Vec<ImbalanceResult>,
     pub rho: Option<f64>,
     pub linear_params: Option<(f64, f64)>,
+    pub linear_depth_center: Option<f64>,
+    pub linear_depth_scale: Option<f64>,
     pub n_observations: usize,
     pub effective_phased: bool,
 }
@@ -80,14 +82,21 @@ pub struct AnalysisConfig {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AnalysisMethod {
     Single, // Single global dispersion parameter
-    Linear, // Linear dispersion model: rho = expit(d1 + N*d2)
+    Linear, // Linear dispersion model: rho = expit(d1 + d2*((N-center)/scale))
 }
 
 /// Nuisance parameters fitted under the balanced beta-binomial null.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum DispersionParameters {
-    Single { rho: f64 },
-    Linear { d1: f64, d2: f64 },
+    Single {
+        rho: f64,
+    },
+    Linear {
+        d1: f64,
+        d2: f64,
+        depth_center: f64,
+        depth_scale: f64,
+    },
 }
 
 impl DispersionParameters {
@@ -98,16 +107,33 @@ impl DispersionParameters {
                     anyhow::bail!("fixed scalar rho must be finite and in [0, 1]");
                 }
             }
-            (AnalysisMethod::Linear, Self::Linear { d1, d2 }) => {
+            (
+                AnalysisMethod::Linear,
+                Self::Linear {
+                    d1,
+                    d2,
+                    depth_center,
+                    depth_scale,
+                },
+            ) => {
                 if !d1.is_finite() || !d2.is_finite() {
                     anyhow::bail!("fixed linear dispersion parameters must be finite");
+                }
+                if !depth_center.is_finite() {
+                    anyhow::bail!("fixed linear depth center must be finite");
+                }
+                if !depth_scale.is_finite() || depth_scale <= 0.0 {
+                    anyhow::bail!("fixed linear depth scale must be finite and positive");
                 }
             }
             (AnalysisMethod::Single, Self::Linear { .. }) => {
                 anyhow::bail!("method 'single' requires a fixed scalar rho");
             }
             (AnalysisMethod::Linear, Self::Single { .. }) => {
-                anyhow::bail!("method 'linear' requires fixed linear_d1 and linear_d2");
+                anyhow::bail!(
+                    "method 'linear' requires fixed linear_d1, linear_d2, \
+                     linear_depth_center, and linear_depth_scale"
+                );
             }
         }
         Ok(self)
@@ -117,9 +143,14 @@ impl DispersionParameters {
     fn rho_at_depth(self, n: u32) -> f64 {
         match self {
             Self::Single { rho } => clamp_rho(rho),
-            Self::Linear { d1, d2 } => {
-                let exp_in = (d1 + n as f64 * d2).clamp(-10.0, 10.0);
-                clamp_rho(expit(exp_in))
+            Self::Linear {
+                d1,
+                d2,
+                depth_center,
+                depth_scale,
+            } => {
+                let standardized_depth = (n as f64 - depth_center) / depth_scale;
+                clamp_rho(expit(d1 + standardized_depth * d2))
             }
         }
     }
@@ -134,7 +165,18 @@ impl DispersionParameters {
     pub fn linear_params(self) -> Option<(f64, f64)> {
         match self {
             Self::Single { .. } => None,
-            Self::Linear { d1, d2 } => Some((d1, d2)),
+            Self::Linear { d1, d2, .. } => Some((d1, d2)),
+        }
+    }
+
+    pub fn linear_depth_standardization(self) -> Option<(f64, f64)> {
+        match self {
+            Self::Single { .. } => None,
+            Self::Linear {
+                depth_center,
+                depth_scale,
+                ..
+            } => Some((depth_center, depth_scale)),
         }
     }
 }
@@ -322,19 +364,66 @@ fn optimize_dispersion(ref_counts: &[u32], n_array: &[u32]) -> Result<f64> {
     scipy_bounded_minimize(objective, 0.0, 1.0, 1e-5, 500)
 }
 
-/// Optimize linear dispersion parameters using Nelder-Mead
+fn depth_standardization(raw_depths: &[u32]) -> Result<(f64, f64)> {
+    if raw_depths.is_empty() {
+        anyhow::bail!("cannot standardize linear depth without observations");
+    }
+
+    // Welford's algorithm avoids cancellation when depths are large and tightly clustered.
+    let mut center = 0.0;
+    let mut squared_deviations = 0.0;
+    for (index, &depth) in raw_depths.iter().enumerate() {
+        let depth = depth as f64;
+        let count = (index + 1) as f64;
+        let delta = depth - center;
+        center += delta / count;
+        squared_deviations += delta * (depth - center);
+    }
+
+    if !center.is_finite() {
+        anyhow::bail!("linear depth center is non-finite");
+    }
+    let variance = squared_deviations / raw_depths.len() as f64;
+    let scale = variance.sqrt();
+    if !scale.is_finite() {
+        anyhow::bail!("linear depth scale is non-finite");
+    }
+    if scale <= 0.0 {
+        anyhow::bail!("linear dispersion requires non-zero raw depth variance");
+    }
+    Ok((center, scale))
+}
+
+/// Optimize standardized linear dispersion parameters using Nelder-Mead.
 ///
-/// Python equivalent: `minimize(opt_linear, x0=(0, 0), method="Nelder-Mead")`
-/// Fits ρ = expit(d1 + N × d2) to the data.
-fn optimize_dispersion_linear(ref_counts: &[u32], n_array: &[u32]) -> Result<(f64, f64)> {
+/// Fits rho = expit(d1 + d2 * ((N - center) / scale)) using raw read depth for
+/// the predictor and pseudocounted observations for the beta-binomial likelihood.
+fn optimize_dispersion_linear(
+    ref_counts: &[u32],
+    n_array: &[u32],
+    raw_depths: &[u32],
+) -> Result<(f64, f64, f64, f64)> {
+    if ref_counts.len() != n_array.len() || ref_counts.len() != raw_depths.len() {
+        anyhow::bail!("linear dispersion inputs have inconsistent lengths");
+    }
+    let (depth_center, depth_scale) = depth_standardization(raw_depths)?;
+
     let objective = |params: [f64; 2]| -> f64 {
         let (d1, d2) = (params[0], params[1]);
+        if !d1.is_finite() || !d2.is_finite() {
+            return f64::INFINITY;
+        }
         let mut neg_ll = 0.0;
 
-        for (&ref_count, &n) in ref_counts.iter().zip(n_array.iter()) {
-            // Clamp to prevent overflow in expit
-            let exp_in = (d1 + n as f64 * d2).clamp(-10.0, 10.0);
-            let rho = clamp_rho(expit(exp_in));
+        for ((&ref_count, &n), &raw_depth) in
+            ref_counts.iter().zip(n_array.iter()).zip(raw_depths.iter())
+        {
+            let standardized_depth = (raw_depth as f64 - depth_center) / depth_scale;
+            let predictor = d1 + standardized_depth * d2;
+            if predictor.is_nan() {
+                return f64::INFINITY;
+            }
+            let rho = clamp_rho(expit(predictor));
             let alpha = 0.5 * (1.0 - rho) / rho;
 
             // Beta-binomial log-pmf with α = β (null: p=0.5)
@@ -349,21 +438,20 @@ fn optimize_dispersion_linear(ref_counts: &[u32], n_array: &[u32]) -> Result<(f6
         neg_ll
     };
 
-    // Multi-start Nelder-Mead. A single start at (0,0) can stall on the flat plateau
-    // created by the exp_in clamp (when |d1 + N*d2| > 10 for all N, rho is constant, so
-    // the surface has no descent direction and the simplex collapses at an unconverged,
-    // worse point). Run NM from a neutral grid of starts spanning the plausible (d1,d2)
-    // range and keep the best (lowest neg-LL). Deterministic; starts are NOT seeded near
-    // any expected answer. Fixes the case where the simple simplex returned e.g. (1.5,-2.0).
-    let starts: [[f64; 2]; 8] = [
-        [0.0, 0.0],
-        [-3.0, 0.0],
-        [-6.0, 0.0],
-        [3.0, 0.0],
-        [0.0, -0.2],
-        [-3.0, -0.2],
-        [-6.0, -0.2],
-        [3.0, -0.2],
+    // A constant-rho fit provides a data-driven intercept. Standardization makes
+    // fixed slope starts meaningful across donors with different depth ranges.
+    let scalar_rho = clamp_rho(optimize_dispersion(ref_counts, n_array)?);
+    let scalar_intercept = (scalar_rho / (1.0 - scalar_rho)).ln();
+    let starts: [[f64; 2]; 9] = [
+        [scalar_intercept, 0.0],
+        [scalar_intercept, -0.25],
+        [scalar_intercept, 0.25],
+        [scalar_intercept, -1.0],
+        [scalar_intercept, 1.0],
+        [scalar_intercept - 2.0, 0.0],
+        [scalar_intercept + 2.0, 0.0],
+        [0.0, -0.5],
+        [0.0, 0.5],
     ];
     let mut best: Option<(f64, (f64, f64))> = None;
     for s in starts {
@@ -374,8 +462,10 @@ fn optimize_dispersion_linear(ref_counts: &[u32], n_array: &[u32]) -> Result<(f6
             }
         }
     }
-    best.map(|(_, p)| p)
-        .ok_or_else(|| anyhow::anyhow!("linear dispersion optimization failed from all starts"))
+    let (d1, d2) = best
+        .map(|(_, parameters)| parameters)
+        .ok_or_else(|| anyhow::anyhow!("linear dispersion optimization failed from all starts"))?;
+    Ok((d1, d2, depth_center, depth_scale))
 }
 
 /// Optimize probability parameter for alternative model
@@ -887,7 +977,7 @@ fn single_model_with_dispersion(
     }
 
     eprintln!("Optimizing dispersion parameter...");
-    let parameters = fit_dispersion_parameters(&variants, AnalysisMethod::Single)?;
+    let parameters = fit_dispersion_parameters(&variants, AnalysisMethod::Single, 0)?;
     let DispersionParameters::Single { rho: disp } = parameters else {
         unreachable!("single fit returned linear parameters")
     };
@@ -903,7 +993,7 @@ pub fn single_model(variants: Vec<VariantCounts>, phased: bool) -> Result<Vec<Im
 /// Linear dispersion model analysis
 ///
 /// Python equivalent: `linear_model()` in as_analysis.py
-/// Uses ρ = expit(d1 + N × d2) where d1, d2 are globally optimized parameters.
+/// Uses standardized raw depth for the globally optimized linear predictor.
 pub fn linear_model_with_dispersion(
     variants: Vec<VariantCounts>,
     phased: bool,
@@ -913,8 +1003,8 @@ pub fn linear_model_with_dispersion(
     }
 
     eprintln!("Optimizing linear dispersion parameters...");
-    let parameters = fit_dispersion_parameters(&variants, AnalysisMethod::Linear)?;
-    let DispersionParameters::Linear { d1, d2 } = parameters else {
+    let parameters = fit_dispersion_parameters(&variants, AnalysisMethod::Linear, 0)?;
+    let DispersionParameters::Linear { d1, d2, .. } = parameters else {
         unreachable!("linear fit returned scalar parameters")
     };
     eprintln!("  d1 = {:.6}, d2 = {:.6}", d1, d2);
@@ -929,6 +1019,7 @@ pub fn linear_model(variants: Vec<VariantCounts>, phased: bool) -> Result<Vec<Im
 fn fit_dispersion_parameters(
     variants: &[VariantCounts],
     method: AnalysisMethod,
+    pseudocount: u32,
 ) -> Result<DispersionParameters> {
     if variants.is_empty() {
         anyhow::bail!("cannot fit dispersion without observations");
@@ -944,10 +1035,32 @@ fn fit_dispersion_parameters(
             rho: optimize_dispersion(&ref_counts, &n_array)?,
         }),
         AnalysisMethod::Linear => {
-            let (d1, d2) = optimize_dispersion_linear(&ref_counts, &n_array)?;
-            Ok(DispersionParameters::Linear { d1, d2 })
+            let raw_depths: Vec<u32> = variants
+                .iter()
+                .map(|variant| raw_depth(variant, pseudocount))
+                .collect::<Result<_>>()?;
+            let (d1, d2, depth_center, depth_scale) =
+                optimize_dispersion_linear(&ref_counts, &n_array, &raw_depths)?;
+            Ok(DispersionParameters::Linear {
+                d1,
+                d2,
+                depth_center,
+                depth_scale,
+            })
         }
     }
+}
+
+fn raw_depth(variant: &VariantCounts, pseudocount: u32) -> Result<u32> {
+    let raw_ref = variant.ref_count.checked_sub(pseudocount).ok_or_else(|| {
+        anyhow::anyhow!("reference count is smaller than the configured pseudocount")
+    })?;
+    let raw_alt = variant.alt_count.checked_sub(pseudocount).ok_or_else(|| {
+        anyhow::anyhow!("alternate count is smaller than the configured pseudocount")
+    })?;
+    raw_ref
+        .checked_add(raw_alt)
+        .ok_or_else(|| anyhow::anyhow!("raw read depth exceeds the supported range"))
 }
 
 fn canonicalize_region_indices(
@@ -984,9 +1097,13 @@ fn test_fixed_dispersion(
         .iter()
         .map(|variant| variant.ref_count + variant.alt_count)
         .collect();
-    let rho_array: Vec<f64> = n_array
+    let raw_depths: Vec<u32> = variants
         .iter()
-        .map(|&n| parameters.rho_at_depth(n))
+        .map(|variant| raw_depth(variant, pseudocount))
+        .collect::<Result<_>>()?;
+    let rho_array: Vec<f64> = raw_depths
+        .iter()
+        .map(|&depth| parameters.rho_at_depth(depth))
         .collect();
 
     let mut region_map: HashMap<String, Vec<usize>> = HashMap::new();
@@ -1061,10 +1178,7 @@ fn test_fixed_dispersion(
                 let raw_ref = variant.ref_count.checked_sub(pseudocount).ok_or_else(|| {
                     anyhow::anyhow!("reference count is smaller than the pseudocount")
                 })?;
-                let raw_alt = variant.alt_count.checked_sub(pseudocount).ok_or_else(|| {
-                    anyhow::anyhow!("alternate count is smaller than the pseudocount")
-                })?;
-                let raw_n = raw_ref + raw_alt;
+                let raw_n = raw_depth(variant, pseudocount)?;
                 exact_beta_binomial_pvalue(raw_ref, raw_n, parameters.rho_at_depth(raw_n))?
             } else {
                 let chi2 =
@@ -1184,6 +1298,12 @@ fn analyze_prepared(
         results,
         rho: parameters.rho(),
         linear_params: parameters.linear_params(),
+        linear_depth_center: parameters
+            .linear_depth_standardization()
+            .map(|standardization| standardization.0),
+        linear_depth_scale: parameters
+            .linear_depth_standardization()
+            .map(|standardization| standardization.1),
         n_observations,
         effective_phased: prepared.effective_phased,
     })
@@ -1203,11 +1323,20 @@ pub fn fit_imbalance_dispersion(
         AnalysisMethod::Single => eprintln!("Optimizing dispersion parameter..."),
         AnalysisMethod::Linear => eprintln!("Optimizing linear dispersion parameters..."),
     }
-    let parameters = fit_dispersion_parameters(&prepared.variants, config.method)?;
+    let parameters =
+        fit_dispersion_parameters(&prepared.variants, config.method, config.pseudocount)?;
     match parameters {
         DispersionParameters::Single { rho } => eprintln!("  Dispersion: {:.6}", rho),
-        DispersionParameters::Linear { d1, d2 } => {
-            eprintln!("  d1 = {:.6}, d2 = {:.6}", d1, d2)
+        DispersionParameters::Linear {
+            d1,
+            d2,
+            depth_center,
+            depth_scale,
+        } => {
+            eprintln!(
+                "  d1 = {:.6}, d2 = {:.6}, depth center = {:.6}, depth scale = {:.6}",
+                d1, d2, depth_center, depth_scale
+            )
         }
     }
     Ok(DispersionFit {
@@ -1239,6 +1368,8 @@ pub fn analyze_imbalance_detailed(
             results: vec![],
             rho: None,
             linear_params: None,
+            linear_depth_center: None,
+            linear_depth_scale: None,
             n_observations,
             effective_phased: prepared.effective_phased,
         });
@@ -1248,11 +1379,20 @@ pub fn analyze_imbalance_detailed(
         AnalysisMethod::Single => eprintln!("Optimizing dispersion parameter..."),
         AnalysisMethod::Linear => eprintln!("Optimizing linear dispersion parameters..."),
     }
-    let parameters = fit_dispersion_parameters(&prepared.variants, config.method)?;
+    let parameters =
+        fit_dispersion_parameters(&prepared.variants, config.method, config.pseudocount)?;
     match parameters {
         DispersionParameters::Single { rho } => eprintln!("  Dispersion: {:.6}", rho),
-        DispersionParameters::Linear { d1, d2 } => {
-            eprintln!("  d1 = {:.6}, d2 = {:.6}", d1, d2)
+        DispersionParameters::Linear {
+            d1,
+            d2,
+            depth_center,
+            depth_scale,
+        } => {
+            eprintln!(
+                "  d1 = {:.6}, d2 = {:.6}, depth center = {:.6}, depth scale = {:.6}",
+                d1, d2, depth_center, depth_scale
+            )
         }
     }
     analyze_prepared(prepared, config, parameters, false)
@@ -1320,6 +1460,42 @@ mod tests {
         assert!((clamp_rho(0.5) - 0.5).abs() < 1e-15);
         assert!((clamp_rho(-1.0) - RHO_EPSILON).abs() < 1e-15);
         assert!((clamp_rho(2.0) - (1.0 - RHO_EPSILON)).abs() < 1e-15);
+    }
+
+    #[test]
+    fn test_standardized_linear_predictor_is_algebraically_equivalent() {
+        let raw_intercept = -4.0;
+        let raw_slope = 0.02;
+        let depth_center = 20.0;
+        let depth_scale = 5.0;
+        let parameters = DispersionParameters::Linear {
+            d1: raw_intercept + raw_slope * depth_center,
+            d2: raw_slope * depth_scale,
+            depth_center,
+            depth_scale,
+        };
+
+        for depth in [0, 10, 20, 40, 100] {
+            let expected = clamp_rho(expit(raw_intercept + raw_slope * depth as f64));
+            assert!((parameters.rho_at_depth(depth) - expected).abs() < 1e-15);
+        }
+    }
+
+    #[test]
+    fn test_linear_predictor_is_not_clipped() {
+        let parameters = DispersionParameters::Linear {
+            d1: 0.0,
+            d2: 100.0,
+            depth_center: 0.0,
+            depth_scale: 1.0,
+        };
+        assert!(parameters.rho_at_depth(1) > 0.999999);
+    }
+
+    #[test]
+    fn test_depth_standardization_rejects_zero_variance() {
+        let error = depth_standardization(&[20, 20, 20]).unwrap_err();
+        assert!(error.to_string().contains("non-zero raw depth variance"));
     }
 
     #[test]
@@ -1524,6 +1700,8 @@ mod tests {
         let nuisance = DispersionParameters::Linear {
             d1: -3.0,
             d2: 0.025,
+            depth_center: 20.0,
+            depth_scale: 5.0,
         };
 
         let forward =
@@ -1581,6 +1759,8 @@ mod tests {
         let nuisance = DispersionParameters::Linear {
             d1: -4.25,
             d2: 0.031,
+            depth_center: 10.0,
+            depth_scale: 2.0,
         };
         let output = analyze_imbalance_with_fixed_dispersion(
             vec![vc_peak(100, 7, 5, None)],
@@ -1590,7 +1770,66 @@ mod tests {
         )
         .unwrap();
         assert_eq!(output.linear_params, Some((-4.25, 0.031)));
+        assert_eq!(output.linear_depth_center, Some(10.0));
+        assert_eq!(output.linear_depth_scale, Some(2.0));
         assert_eq!(output.rho, None);
         assert_eq!(output.n_observations, 1);
+    }
+
+    #[test]
+    fn test_fixed_linear_nuisance_rejects_invalid_scale() {
+        let config = AnalysisConfig {
+            min_count: 0,
+            pseudocount: 0,
+            method: AnalysisMethod::Linear,
+            phased: false,
+        };
+        for depth_scale in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            let error = analyze_imbalance_with_fixed_dispersion(
+                vec![vc_peak(100, 7, 5, None)],
+                &config,
+                DispersionParameters::Linear {
+                    d1: -4.0,
+                    d2: 0.1,
+                    depth_center: 12.0,
+                    depth_scale,
+                },
+                false,
+            )
+            .unwrap_err();
+            assert!(error.to_string().contains("finite and positive"));
+        }
+    }
+
+    #[test]
+    fn test_linear_fit_reports_raw_depth_standardization() {
+        let variants = vec![
+            vc_peak(100, 8, 2, None),
+            vc_peak(200, 10, 10, None),
+            vc_peak(300, 18, 12, None),
+        ];
+        let config = AnalysisConfig {
+            min_count: 0,
+            pseudocount: 3,
+            method: AnalysisMethod::Linear,
+            phased: false,
+        };
+        let fit = fit_imbalance_dispersion(variants, &config).unwrap();
+        let (center, scale) = fit.parameters.linear_depth_standardization().unwrap();
+        assert!((center - 20.0).abs() < 1e-12);
+        assert!((scale - (200.0_f64 / 3.0).sqrt()).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_linear_fit_rejects_zero_raw_depth_variance() {
+        let variants = vec![vc_peak(100, 8, 2, None), vc_peak(200, 6, 4, None)];
+        let config = AnalysisConfig {
+            min_count: 0,
+            pseudocount: 2,
+            method: AnalysisMethod::Linear,
+            phased: false,
+        };
+        let error = fit_imbalance_dispersion(variants, &config).unwrap_err();
+        assert!(error.to_string().contains("non-zero raw depth variance"));
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,8 +1,4 @@
-#![allow(
-    clippy::too_many_arguments,
-    clippy::type_complexity,
-    non_local_definitions
-)]
+#![allow(non_local_definitions)]
 
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
@@ -268,169 +264,195 @@ fn remap_all_chromosomes(
 /// for r in results:
 ///     print(f"{r['region']}: pval={r['pval']:.4f}")
 /// ```
-#[pyfunction]
-#[pyo3(signature = (tsv_path, min_count=10, pseudocount=1, method="single", phased=false, region_col=None))]
-fn analyze_imbalance(
-    py: Python,
+fn parse_analysis_method(method: &str) -> PyResult<analysis::AnalysisMethod> {
+    match method {
+        "single" => Ok(analysis::AnalysisMethod::Single),
+        "linear" => Ok(analysis::AnalysisMethod::Linear),
+        "per_donor" => Err(PyRuntimeError::new_err(
+            "method='per_donor' has been removed because it pooled effect likelihoods across donors; split the count table by donor, fit each donor with fit_imbalance_dispersion(), and pass those fixed nuisance parameters to analyze_imbalance_run()",
+        )),
+        _ => Err(PyRuntimeError::new_err(format!(
+            "Unknown method '{method}'; expected 'single' or 'linear'"
+        ))),
+    }
+}
+
+fn fixed_dispersion_parameters(
+    method: analysis::AnalysisMethod,
+    rho: Option<f64>,
+    linear_d1: Option<f64>,
+    linear_d2: Option<f64>,
+) -> PyResult<Option<analysis::DispersionParameters>> {
+    match method {
+        analysis::AnalysisMethod::Single => {
+            if linear_d1.is_some() || linear_d2.is_some() {
+                return Err(PyRuntimeError::new_err(
+                    "method='single' accepts rho, not linear_d1/linear_d2",
+                ));
+            }
+            Ok(rho.map(|rho| analysis::DispersionParameters::Single { rho }))
+        }
+        analysis::AnalysisMethod::Linear => {
+            if rho.is_some() {
+                return Err(PyRuntimeError::new_err(
+                    "method='linear' accepts linear_d1/linear_d2, not rho",
+                ));
+            }
+            match (linear_d1, linear_d2) {
+                (None, None) => Ok(None),
+                (Some(d1), Some(d2)) => Ok(Some(analysis::DispersionParameters::Linear { d1, d2 })),
+                _ => Err(PyRuntimeError::new_err(
+                    "method='linear' requires both linear_d1 and linear_d2",
+                )),
+            }
+        }
+    }
+}
+
+fn read_analysis_variants(
     tsv_path: &str,
-    min_count: u32,
-    pseudocount: u32,
-    method: &str,
-    phased: bool,
-    region_col: Option<String>,
-) -> PyResult<Py<PyAny>> {
-    use pyo3::types::{PyDict, PyList};
+    region_col: Option<&str>,
+) -> PyResult<Vec<analysis::VariantCounts>> {
+    use flate2::read::MultiGzDecoder;
+    use std::collections::HashSet;
     use std::fs::File;
     use std::io::{BufRead, BufReader};
 
-    // Parse method
-    let analysis_method = match method {
-        "single" => analysis::AnalysisMethod::Single,
-        "linear" => analysis::AnalysisMethod::Linear,
-        "per_donor" => analysis::AnalysisMethod::PerDonor,
-        _ => {
-            return Err(PyRuntimeError::new_err(format!(
-                "Unknown method: {}",
-                method
-            )))
-        }
-    };
-
-    let config = analysis::AnalysisConfig {
-        min_count,
-        pseudocount,
-        method: analysis_method,
-        phased,
-    };
-
-    // Read TSV file
     let file = File::open(tsv_path)
-        .map_err(|e| PyRuntimeError::new_err(format!("Failed to open TSV: {}", e)))?;
-    let reader = BufReader::new(file);
+        .map_err(|e| PyRuntimeError::new_err(format!("Failed to open TSV: {e}")))?;
+    let mut reader: Box<dyn BufRead> = if tsv_path.ends_with(".gz") {
+        Box::new(BufReader::new(MultiGzDecoder::new(file)))
+    } else {
+        Box::new(BufReader::new(file))
+    };
+
+    let mut header_line = String::new();
+    if reader
+        .read_line(&mut header_line)
+        .map_err(|e| PyRuntimeError::new_err(format!("Failed to read TSV header: {e}")))?
+        == 0
+    {
+        return Err(PyRuntimeError::new_err("Count TSV is empty"));
+    }
+    let headers: Vec<&str> = header_line
+        .trim_end_matches(['\r', '\n'])
+        .split('\t')
+        .collect();
+    let unique: HashSet<&str> = headers.iter().copied().collect();
+    if unique.len() != headers.len() {
+        return Err(PyRuntimeError::new_err(
+            "Count TSV contains duplicate column names",
+        ));
+    }
+    for name in ["chrom", "pos", "ref", "alt", "ref_count", "alt_count"] {
+        if !unique.contains(name) {
+            return Err(PyRuntimeError::new_err(format!(
+                "Required column '{name}' is missing from count TSV"
+            )));
+        }
+    }
+    let index = |name: &str| {
+        headers
+            .iter()
+            .position(|header| *header == name)
+            .expect("required header checked")
+    };
+    let chrom_idx = index("chrom");
+    let pos_idx = index("pos");
+    let ref_idx = index("ref");
+    let alt_idx = index("alt");
+    let ref_count_idx = index("ref_count");
+    let alt_count_idx = index("alt_count");
+    let gt_idx = headers.iter().position(|header| *header == "GT");
+    let region_idx = match region_col {
+        Some(name) => Some(
+            headers
+                .iter()
+                .position(|header| *header == name)
+                .ok_or_else(|| {
+                    PyRuntimeError::new_err(format!(
+                        "region_col '{name}' not found in header columns: {headers:?}"
+                    ))
+                })?,
+        ),
+        None => None,
+    };
 
     let mut variants = Vec::new();
-
-    // Resolve columns from the header. Count tables can carry pos0, GT, feature,
-    // parent, sample, or donor metadata, so fixed offsets are not reliable.
-    let mut chrom_idx: usize = 0;
-    let mut pos_idx: usize = 1;
-    let mut ref_count_idx: usize = 4;
-    let mut alt_count_idx: usize = 5;
-    let mut gt_idx: Option<usize> = None;
-    // Region column index (use input region names instead of chrom_pos format)
-    let mut region_idx: Option<usize> = None;
-    // Optional donor/sample column (used by the per_donor model)
-    let mut sample_idx: Option<usize> = None;
-    let mut header_seen = false;
-
-    for (line_idx, line) in reader.lines().enumerate() {
-        let line =
-            line.map_err(|e| PyRuntimeError::new_err(format!("Failed to read line: {}", e)))?;
-
-        if !header_seen {
-            header_seen = true;
-            let headers: Vec<&str> = line.split('\t').collect();
-            let required_column = |name: &str| {
-                headers
-                    .iter()
-                    .position(|header| *header == name)
-                    .ok_or_else(|| {
-                        PyRuntimeError::new_err(format!(
-                            "Required column '{}' not found in header columns: {:?}",
-                            name, headers
-                        ))
-                    })
-            };
-            chrom_idx = required_column("chrom")?;
-            pos_idx = required_column("pos")?;
-            ref_count_idx = required_column("ref_count")?;
-            alt_count_idx = required_column("alt_count")?;
-            gt_idx = headers.iter().position(|header| *header == "GT");
-            // Detect an optional `sample` column by name (per_donor input)
-            sample_idx = headers.iter().position(|h| *h == "sample");
-            // Resolve grouping column from the region_col argument (mirror Python get_imbalance):
-            //   Some(name) => group by that column (error if the column is absent)
-            //   None       => per-variant grouping (chrom_pos), ignoring any "region" column
-            region_idx = match &region_col {
-                Some(name) => match headers.iter().position(|h| *h == name.as_str()) {
-                    Some(ix) => Some(ix),
-                    None => {
-                        return Err(PyRuntimeError::new_err(format!(
-                            "region_col '{}' not found in header columns: {:?}",
-                            name, headers
-                        )))
-                    }
-                },
-                None => None,
-            };
-            continue;
-        }
-
-        if line.trim().is_empty() {
-            continue;
+    for (offset, line) in reader.lines().enumerate() {
+        let line_number = offset + 2;
+        let line = line.map_err(|e| {
+            PyRuntimeError::new_err(format!("Failed to read line {line_number}: {e}"))
+        })?;
+        if line.is_empty() {
+            return Err(PyRuntimeError::new_err(format!(
+                "Blank row at line {line_number}"
+            )));
         }
         let fields: Vec<&str> = line.split('\t').collect();
-        let field = |index: usize, name: &str| {
-            fields.get(index).copied().ok_or_else(|| {
-                PyRuntimeError::new_err(format!(
-                    "Missing '{}' value on TSV line {}",
-                    name,
-                    line_idx + 1
-                ))
-            })
-        };
+        if fields.len() != headers.len() {
+            return Err(PyRuntimeError::new_err(format!(
+                "Line {line_number} has {} fields; expected {}",
+                fields.len(),
+                headers.len()
+            )));
+        }
 
-        let chrom = field(chrom_idx, "chrom")?.to_string();
-        let pos = field(pos_idx, "pos")?
-            .parse::<u32>()
-            .map_err(|e| PyRuntimeError::new_err(format!("Invalid pos: {}", e)))?;
-        let ref_count = field(ref_count_idx, "ref_count")?
-            .parse::<u32>()
-            .map_err(|e| PyRuntimeError::new_err(format!("Invalid ref_count: {}", e)))?;
-        let alt_count = field(alt_count_idx, "alt_count")?
-            .parse::<u32>()
-            .map_err(|e| PyRuntimeError::new_err(format!("Invalid alt_count: {}", e)))?;
-
-        // region_col=Some => use that column verbatim; region_col=None => per-variant chrom_pos.
-        // The chrom_pos label matches Python's df["chrom"] + "_" + df["pos"] for SNV-solo parity.
-        let region = match region_idx {
-            Some(ri) => field(ri, "region")?.to_string(),
-            None => format!("{}_{}", chrom, pos),
-        };
-
-        let sample = sample_idx.and_then(|si| fields.get(si).map(|s| s.to_string()));
-
-        // Parse the phased genotype (GT) column when present.
-        // Only fully-phased hets map to a value; everything else (unphased,
-        // homozygous, missing) is None. Emits ONLY Some(0)/Some(1)/None so
-        // downstream `1 - g` on u8 never underflows.
-        //
-        // AHO parity: only numeric VCF-style phased heterozygotes are trusted.
-        // Allele-string GT values such as "A|G" are not interpreted as
-        // cross-SNV haplotype phase by the archived Python implementation.
-        let gt: Option<u8> = gt_idx.and_then(|gi| {
-            let gt_str = fields.get(gi)?;
-            parse_numeric_phased_gt(gt_str)
-        });
-
+        let chrom = fields[chrom_idx].to_string();
+        let ref_allele = fields[ref_idx];
+        let alt_allele = fields[alt_idx];
+        if chrom.is_empty() || ref_allele.is_empty() || alt_allele.is_empty() {
+            return Err(PyRuntimeError::new_err(format!(
+                "Empty chromosome, REF, or ALT value at line {line_number}"
+            )));
+        }
+        if ref_allele == alt_allele || alt_allele.contains(',') {
+            return Err(PyRuntimeError::new_err(format!(
+                "Line {line_number} is not a biallelic REF/ALT observation"
+            )));
+        }
+        let pos = fields[pos_idx].parse::<u32>().map_err(|e| {
+            PyRuntimeError::new_err(format!("Invalid pos at line {line_number}: {e}"))
+        })?;
+        if pos == 0 {
+            return Err(PyRuntimeError::new_err(format!(
+                "Position must be one-based at line {line_number}"
+            )));
+        }
+        let ref_count = fields[ref_count_idx].parse::<u32>().map_err(|e| {
+            PyRuntimeError::new_err(format!("Invalid ref_count at line {line_number}: {e}"))
+        })?;
+        let alt_count = fields[alt_count_idx].parse::<u32>().map_err(|e| {
+            PyRuntimeError::new_err(format!("Invalid alt_count at line {line_number}: {e}"))
+        })?;
+        let region = region_idx
+            .map(|idx| fields[idx].to_string())
+            .unwrap_or_else(|| format!("{chrom}_{pos}"));
+        if region.is_empty() {
+            return Err(PyRuntimeError::new_err(format!(
+                "Empty region at line {line_number}"
+            )));
+        }
+        let gt = gt_idx.and_then(|idx| parse_numeric_phased_gt(fields[idx]));
         variants.push(analysis::VariantCounts {
             chrom,
             pos,
             ref_count,
             alt_count,
             region,
-            sample,
             gt,
         });
     }
+    Ok(variants)
+}
 
-    // Run analysis
-    let results = analysis::analyze_imbalance(variants, &config)
-        .map_err(|e| PyRuntimeError::new_err(format!("Analysis failed: {}", e)))?;
+fn results_to_py<'py>(
+    py: Python<'py>,
+    results: Vec<analysis::ImbalanceResult>,
+) -> PyResult<Bound<'py, pyo3::types::PyList>> {
+    use pyo3::types::{PyDict, PyList};
 
-    // Convert to Python list of dicts
     let py_list = PyList::empty(py);
-
     for result in results {
         let py_dict = PyDict::new(py);
         py_dict.set_item("region", result.region)?;
@@ -446,8 +468,146 @@ fn analyze_imbalance(
         py_dict.set_item("fdr_pval", result.fdr_pval)?;
         py_list.append(py_dict)?;
     }
+    Ok(py_list)
+}
 
-    Ok(py_list.unbind().into_any())
+#[pyfunction]
+#[pyo3(signature = (tsv_path, min_count=10, pseudocount=1, method="single", phased=false, region_col=None))]
+fn analyze_imbalance(
+    py: Python,
+    tsv_path: &str,
+    min_count: u32,
+    pseudocount: u32,
+    method: &str,
+    phased: bool,
+    region_col: Option<String>,
+) -> PyResult<Py<PyAny>> {
+    let config = analysis::AnalysisConfig {
+        min_count,
+        pseudocount,
+        method: parse_analysis_method(method)?,
+        phased,
+    };
+    let variants = read_analysis_variants(tsv_path, region_col.as_deref())?;
+    let output = analysis::analyze_imbalance_detailed(variants, &config)
+        .map_err(|e| PyRuntimeError::new_err(format!("Analysis failed: {e}")))?;
+    Ok(results_to_py(py, output.results)?.unbind().into_any())
+}
+
+/// Fit balanced-null dispersion without testing allelic effects.
+#[pyfunction]
+#[pyo3(signature = (tsv_path, min_count=10, pseudocount=1, method="single", phased=false, region_col=None))]
+fn fit_imbalance_dispersion(
+    py: Python,
+    tsv_path: &str,
+    min_count: u32,
+    pseudocount: u32,
+    method: &str,
+    phased: bool,
+    region_col: Option<String>,
+) -> PyResult<Py<PyAny>> {
+    use pyo3::types::PyDict;
+
+    let analysis_method = parse_analysis_method(method)?;
+    let config = analysis::AnalysisConfig {
+        min_count,
+        pseudocount,
+        method: analysis_method,
+        phased,
+    };
+    let variants = read_analysis_variants(tsv_path, region_col.as_deref())?;
+    let fit = analysis::fit_imbalance_dispersion(variants, &config)
+        .map_err(|e| PyRuntimeError::new_err(format!("Dispersion fitting failed: {e}")))?;
+
+    let result = PyDict::new(py);
+    result.set_item("method", method)?;
+    result.set_item("rho", fit.parameters.rho())?;
+    result.set_item(
+        "linear_d1",
+        fit.parameters.linear_params().map(|params| params.0),
+    )?;
+    result.set_item(
+        "linear_d2",
+        fit.parameters.linear_params().map(|params| params.1),
+    )?;
+    result.set_item("n_observations", fit.n_observations)?;
+    Ok(result.unbind().into_any())
+}
+
+/// Analyze one independent count table and return dispersion metadata.
+///
+/// Supplying `rho` (single) or `linear_d1`/`linear_d2` (linear) runs a
+/// fixed-nuisance test. Omitting them retains the legacy fit-and-test behavior.
+#[pyfunction]
+#[pyo3(signature = (tsv_path, min_count=10, pseudocount=1, phased=false, region_col=None, method="single", rho=None, linear_d1=None, linear_d2=None, exact_snv=None))]
+#[allow(clippy::too_many_arguments)]
+fn analyze_imbalance_run(
+    py: Python,
+    tsv_path: &str,
+    min_count: u32,
+    pseudocount: u32,
+    phased: bool,
+    region_col: Option<String>,
+    method: &str,
+    rho: Option<f64>,
+    linear_d1: Option<f64>,
+    linear_d2: Option<f64>,
+    exact_snv: Option<bool>,
+) -> PyResult<Py<PyAny>> {
+    use pyo3::types::PyDict;
+
+    let analysis_method = parse_analysis_method(method)?;
+    let fixed_parameters = fixed_dispersion_parameters(analysis_method, rho, linear_d1, linear_d2)?;
+    let fixed_nuisance = fixed_parameters.is_some();
+    let exact_snv = exact_snv.unwrap_or(fixed_nuisance && region_col.is_none());
+    if exact_snv && !fixed_nuisance {
+        return Err(PyRuntimeError::new_err(
+            "exact_snv=True requires nuisance parameters from fit_imbalance_dispersion()",
+        ));
+    }
+    let config = analysis::AnalysisConfig {
+        min_count,
+        pseudocount,
+        method: analysis_method,
+        phased,
+    };
+    let variants = read_analysis_variants(tsv_path, region_col.as_deref())?;
+    let output = match fixed_parameters {
+        Some(parameters) => analysis::analyze_imbalance_with_fixed_dispersion(
+            variants, &config, parameters, exact_snv,
+        ),
+        None => analysis::analyze_imbalance_detailed(variants, &config),
+    }
+    .map_err(|e| PyRuntimeError::new_err(format!("Analysis failed: {e}")))?;
+    if output.results.is_empty() {
+        return Err(PyRuntimeError::new_err(
+            "No variants passed the count threshold; no results were produced",
+        ));
+    }
+
+    let result = PyDict::new(py);
+    result.set_item("results", results_to_py(py, output.results)?)?;
+    result.set_item("method", method)?;
+    result.set_item("rho", output.rho)?;
+    result.set_item("linear_d1", output.linear_params.map(|params| params.0))?;
+    result.set_item("linear_d2", output.linear_params.map(|params| params.1))?;
+    result.set_item("n_observations", output.n_observations)?;
+    result.set_item("requested_phased", phased)?;
+    result.set_item("effective_phased", output.effective_phased)?;
+    result.set_item(
+        "nuisance_source",
+        if fixed_nuisance { "fixed" } else { "fitted" },
+    )?;
+    result.set_item("exact_snv", exact_snv)?;
+    result.set_item(
+        "pvalue_method",
+        if exact_snv {
+            "beta_binomial_exact_two_sided"
+        } else {
+            "chi_square_lrt"
+        },
+    )?;
+    Ok(result.unbind().into_any())
 }
 
 // ============================================================================
@@ -875,7 +1035,7 @@ fn parse_intersect_bed_multi(
             // Convert sample_alleles to list of tuples
             let alleles_list = PyList::empty(py);
             for (h1, h2) in &span.sample_alleles {
-                let tuple = pyo3::types::PyTuple::new(py, [h1.as_str(), h2.as_str()])?;
+                let tuple = pyo3::types::PyTuple::new(py, &[h1.as_str(), h2.as_str()])?;
                 alleles_list.append(&tuple)?;
             }
             span_dict.set_item("sample_alleles", alleles_list)?;
@@ -972,6 +1132,8 @@ fn sum_as_string(a: usize, b: usize) -> PyResult<String> {
 /// - analyze_imbalance: Fast beta-binomial analysis for AI detection (IMPLEMENTED)
 #[pymodule]
 fn wasp2_rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+
     // Legacy test function
     m.add_function(wrap_pyfunction!(sum_as_string, m)?)?;
 
@@ -1015,6 +1177,8 @@ fn wasp2_rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     // Analysis module (beta-binomial allelic imbalance detection)
     m.add_function(wrap_pyfunction!(analyze_imbalance, m)?)?;
+    m.add_function(wrap_pyfunction!(fit_imbalance_dispersion, m)?)?;
+    m.add_function(wrap_pyfunction!(analyze_imbalance_run, m)?)?;
 
     Ok(())
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,4 +1,8 @@
-#![allow(non_local_definitions)]
+#![allow(
+    clippy::too_many_arguments,
+    clippy::type_complexity,
+    non_local_definitions
+)]
 
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
@@ -1077,7 +1081,7 @@ fn parse_intersect_bed_multi(
             // Convert sample_alleles to list of tuples
             let alleles_list = PyList::empty(py);
             for (h1, h2) in &span.sample_alleles {
-                let tuple = pyo3::types::PyTuple::new(py, &[h1.as_str(), h2.as_str()])?;
+                let tuple = pyo3::types::PyTuple::new(py, [h1.as_str(), h2.as_str()])?;
                 alleles_list.append(&tuple)?;
             }
             span_dict.set_item("sample_alleles", alleles_list)?;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -282,12 +282,18 @@ fn fixed_dispersion_parameters(
     rho: Option<f64>,
     linear_d1: Option<f64>,
     linear_d2: Option<f64>,
+    linear_depth_center: Option<f64>,
+    linear_depth_scale: Option<f64>,
 ) -> PyResult<Option<analysis::DispersionParameters>> {
     match method {
         analysis::AnalysisMethod::Single => {
-            if linear_d1.is_some() || linear_d2.is_some() {
+            if linear_d1.is_some()
+                || linear_d2.is_some()
+                || linear_depth_center.is_some()
+                || linear_depth_scale.is_some()
+            {
                 return Err(PyRuntimeError::new_err(
-                    "method='single' accepts rho, not linear_d1/linear_d2",
+                    "method='single' accepts rho, not linear dispersion parameters",
                 ));
             }
             Ok(rho.map(|rho| analysis::DispersionParameters::Single { rho }))
@@ -298,11 +304,24 @@ fn fixed_dispersion_parameters(
                     "method='linear' accepts linear_d1/linear_d2, not rho",
                 ));
             }
-            match (linear_d1, linear_d2) {
-                (None, None) => Ok(None),
-                (Some(d1), Some(d2)) => Ok(Some(analysis::DispersionParameters::Linear { d1, d2 })),
+            match (
+                linear_d1,
+                linear_d2,
+                linear_depth_center,
+                linear_depth_scale,
+            ) {
+                (None, None, None, None) => Ok(None),
+                (Some(d1), Some(d2), Some(depth_center), Some(depth_scale)) => {
+                    Ok(Some(analysis::DispersionParameters::Linear {
+                        d1,
+                        d2,
+                        depth_center,
+                        depth_scale,
+                    }))
+                }
                 _ => Err(PyRuntimeError::new_err(
-                    "method='linear' requires both linear_d1 and linear_d2",
+                    "fixed method='linear' requires linear_d1, linear_d2, \
+                     linear_depth_center, and linear_depth_scale",
                 )),
             }
         }
@@ -530,16 +549,28 @@ fn fit_imbalance_dispersion(
         "linear_d2",
         fit.parameters.linear_params().map(|params| params.1),
     )?;
+    result.set_item(
+        "linear_depth_center",
+        fit.parameters
+            .linear_depth_standardization()
+            .map(|standardization| standardization.0),
+    )?;
+    result.set_item(
+        "linear_depth_scale",
+        fit.parameters
+            .linear_depth_standardization()
+            .map(|standardization| standardization.1),
+    )?;
     result.set_item("n_observations", fit.n_observations)?;
     Ok(result.unbind().into_any())
 }
 
 /// Analyze one independent count table and return dispersion metadata.
 ///
-/// Supplying `rho` (single) or `linear_d1`/`linear_d2` (linear) runs a
-/// fixed-nuisance test. Omitting them retains the legacy fit-and-test behavior.
+/// Supplying `rho` (single) or all four linear parameters runs a fixed-nuisance
+/// test. Omitting them retains the legacy fit-and-test behavior.
 #[pyfunction]
-#[pyo3(signature = (tsv_path, min_count=10, pseudocount=1, phased=false, region_col=None, method="single", rho=None, linear_d1=None, linear_d2=None, exact_snv=None))]
+#[pyo3(signature = (tsv_path, min_count=10, pseudocount=1, phased=false, region_col=None, method="single", rho=None, linear_d1=None, linear_d2=None, linear_depth_center=None, linear_depth_scale=None, exact_snv=None))]
 #[allow(clippy::too_many_arguments)]
 fn analyze_imbalance_run(
     py: Python,
@@ -552,12 +583,21 @@ fn analyze_imbalance_run(
     rho: Option<f64>,
     linear_d1: Option<f64>,
     linear_d2: Option<f64>,
+    linear_depth_center: Option<f64>,
+    linear_depth_scale: Option<f64>,
     exact_snv: Option<bool>,
 ) -> PyResult<Py<PyAny>> {
     use pyo3::types::PyDict;
 
     let analysis_method = parse_analysis_method(method)?;
-    let fixed_parameters = fixed_dispersion_parameters(analysis_method, rho, linear_d1, linear_d2)?;
+    let fixed_parameters = fixed_dispersion_parameters(
+        analysis_method,
+        rho,
+        linear_d1,
+        linear_d2,
+        linear_depth_center,
+        linear_depth_scale,
+    )?;
     let fixed_nuisance = fixed_parameters.is_some();
     let exact_snv = exact_snv.unwrap_or(fixed_nuisance && region_col.is_none());
     if exact_snv && !fixed_nuisance {
@@ -591,6 +631,8 @@ fn analyze_imbalance_run(
     result.set_item("rho", output.rho)?;
     result.set_item("linear_d1", output.linear_params.map(|params| params.0))?;
     result.set_item("linear_d2", output.linear_params.map(|params| params.1))?;
+    result.set_item("linear_depth_center", output.linear_depth_center)?;
+    result.set_item("linear_depth_scale", output.linear_depth_scale)?;
     result.set_item("n_observations", output.n_observations)?;
     result.set_item("requested_phased", phased)?;
     result.set_item("effective_phased", output.effective_phased)?;

--- a/src/analysis/__main__.py
+++ b/src/analysis/__main__.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Annotated
 
 import typer
@@ -5,8 +6,26 @@ import typer
 from wasp2.cli import create_version_callback, verbosity_callback
 
 from .run_analysis import run_ai_analysis
-from .run_analysis_sc import run_ai_analysis_sc
-from .run_compare_ai import run_ai_comparison
+
+
+class AnalysisScopeChoice(str, Enum):
+    per_donor = "per-donor"
+
+
+class AnalysisUnitChoice(str, Enum):
+    snv = "snv"
+    feature = "feature"
+    peak = "peak"
+
+
+class AnalysisModelChoice(str, Enum):
+    single = "single"
+    linear = "linear"
+
+
+class DispersionScopeChoice(str, Enum):
+    per_donor = "per-donor"
+    global_ = "global"
 
 
 def _get_analysis_deps() -> dict[str, str]:
@@ -55,7 +74,10 @@ def main(
 
 @app.command()
 def find_imbalance(
-    counts: Annotated[str, typer.Argument(help="Count File")],
+    counts: Annotated[
+        str,
+        typer.Argument(help="Count table, locked count bundle, or count_manifest.json."),
+    ],
     min: Annotated[
         int | None,
         typer.Option(
@@ -71,7 +93,10 @@ def find_imbalance(
             "--ps",
             "--pseudo",
             "--pseudocount",
-            help="Pseudocount added when measuring allelic imbalance. (Default: 1)",
+            help=(
+                "Pseudocount added when measuring allelic imbalance. Defaults to 0 for "
+                "--scope per-donor and 1 for the legacy route."
+            ),
         ),
     ] = None,
     out_file: Annotated[
@@ -97,22 +122,22 @@ def find_imbalance(
         ),
     ] = False,
     model: Annotated[
-        str | None,
+        AnalysisModelChoice | None,
         typer.Option(
             "-m",
             "--model",
-            help=(
-                "Model used for measuring optimization parameter when finding imbalance. "
-                "HIGHLY RECOMMENDED TO LEAVE AS DEFAULT FOR SINGLE DISPERSION MODEL. "
-                "Choice of 'single' or 'linear'. (Default: 'single')"
-            ),
+            help=("Dispersion model used for imbalance inference. Defaults to 'single'."),
         ),
     ] = None,
     region_col: Annotated[
         str | None,
         typer.Option(
+            "--region-col",
             "--region_col",
-            help="Name of region column for current data. 'region' for ATAC-seq. Attribute name for RNA-seq. (Default: Auto-parses if none provided)",
+            help=(
+                "Feature identifier column. Locked feature bundles use 'region'; standalone "
+                "feature tables require this option."
+            ),
         ),
     ] = None,
     groupby: Annotated[
@@ -142,17 +167,61 @@ def find_imbalance(
             ),
         ),
     ] = False,
+    scope: Annotated[
+        AnalysisScopeChoice | None,
+        typer.Option(
+            "--scope",
+            help=(
+                "Analyze each donor independently. Requires --unit and canonical donor_id; "
+                "standalone legacy tables may use sample instead."
+            ),
+        ),
+    ] = None,
+    unit: Annotated[
+        AnalysisUnitChoice | None,
+        typer.Option(
+            "--unit",
+            help="Statistical unit: snv or feature. peak is an alias for feature.",
+        ),
+    ] = None,
+    dispersion_scope: Annotated[
+        DispersionScopeChoice,
+        typer.Option(
+            "--dispersion-scope",
+            help="Fit dispersion globally across eligible donor-SNV rows or per donor.",
+        ),
+    ] = DispersionScopeChoice.per_donor,
+    min_donor_observations: Annotated[
+        int,
+        typer.Option(
+            "--min-donor-observations",
+            min=1,
+            help="Exclude donors with fewer eligible unique SNV observations.",
+        ),
+    ] = 50,
+    expected_manifest_sha256: Annotated[
+        str | None,
+        typer.Option(
+            "--expected-manifest-sha256",
+            help="Require a locked bundle manifest with this SHA-256 digest.",
+        ),
+    ] = None,
 ) -> None:
     run_ai_analysis(
         count_file=counts,
         min_count=min,
-        model=model,
+        model=model.value if model is not None else None,
         pseudocount=pseudocount,
         phased=phased,
         out_file=out_file,
         region_col=region_col,
         groupby=groupby,
         per_variant=per_variant,
+        scope=scope.value if scope is not None else None,
+        unit=unit.value if unit is not None else None,
+        dispersion_scope=dispersion_scope.value,
+        min_donor_observations=min_donor_observations,
+        expected_manifest_sha256=expected_manifest_sha256,
     )
 
 
@@ -234,6 +303,13 @@ def find_imbalance_sc(
         ),
     ] = None,
 ) -> None:
+    try:
+        from .run_analysis_sc import run_ai_analysis_sc
+    except (ImportError, ModuleNotFoundError) as error:
+        raise typer.BadParameter(
+            "Single-cell analysis requires: pip install 'wasp2[single-cell]'"
+        ) from error
+
     run_ai_analysis_sc(
         count_file=counts,
         bc_map=bc_map,
@@ -325,6 +401,13 @@ def compare_imbalance(
         ),
     ] = None,
 ) -> None:
+    try:
+        from .run_compare_ai import run_ai_comparison
+    except (ImportError, ModuleNotFoundError) as error:
+        raise typer.BadParameter(
+            "Single-cell comparison requires: pip install 'wasp2[single-cell]'"
+        ) from error
+
     run_ai_comparison(
         count_file=counts,
         bc_map=bc_map,

--- a/src/analysis/run_analysis.py
+++ b/src/analysis/run_analysis.py
@@ -13,6 +13,8 @@ from typing import Literal
 
 import pandas as pd
 
+from .run_analysis_per_donor import run_per_donor_analysis
+
 # Rust analysis (required; no Python fallback)
 try:
     from wasp2_rust import analyze_imbalance as rust_analyze_imbalance
@@ -143,7 +145,12 @@ def run_ai_analysis(
     region_col: str | None = None,
     groupby: str | None = None,
     per_variant: bool = False,
-) -> None:
+    scope: str | None = None,
+    unit: str | None = None,
+    dispersion_scope: str = "per-donor",
+    min_donor_observations: int = 50,
+    expected_manifest_sha256: str | None = None,
+) -> dict[str, Path] | None:
     """Run allelic imbalance analysis pipeline.
 
     Parameters
@@ -153,7 +160,8 @@ def run_ai_analysis(
     min_count : int | None, optional
         Minimum total count threshold, by default 10.
     pseudocount : int | None, optional
-        Pseudocount to add, by default 1.
+        Pseudocount to add. Defaults to 0 for donor-local analysis and 1 for
+        the legacy route.
     phased : bool | None, optional
         Use phased genotype information, by default False.
     model : str | None, optional
@@ -167,12 +175,57 @@ def run_ai_analysis(
     per_variant : bool, optional
         Test each SNV independently (per-variant) instead of grouping by a region column.
         Forces per-variant even when a region column is present. Default False.
+    scope : str | None, optional
+        Set to ``"per-donor"`` to use donor-local orchestration.
+    unit : str | None, optional
+        Donor-local analysis unit: ``"snv"`` or ``"feature"``; ``"peak"`` is an alias.
+    dispersion_scope : str, optional
+        Fit dispersion globally or independently per donor, by default ``"per-donor"``.
+    min_donor_observations : int, optional
+        Minimum eligible unique donor-SNV rows required for inference, by default 50.
+    expected_manifest_sha256 : str | None, optional
+        External trust anchor for a locked count bundle manifest.
 
     Raises
     ------
     RuntimeError
         If Rust analysis extension is not available.
     """
+    if model not in {None, "single", "linear"}:
+        raise ValueError("model must be 'single' or 'linear'")
+    if scope is not None:
+        if scope != "per-donor":
+            raise ValueError("scope must be 'per-donor'")
+        if unit not in {"snv", "feature", "peak"}:
+            raise ValueError(
+                "Per-donor analysis requires --unit snv or --unit feature (--unit peak is an alias)"
+            )
+        if groupby is not None or per_variant:
+            raise ValueError("Per-donor analysis cannot use --groupby or --per-variant")
+        if dispersion_scope not in {"global", "per-donor"}:
+            raise ValueError("dispersion_scope must be 'global' or 'per-donor'")
+        output = out_file if out_file is not None else str(Path.cwd() / "ai_results.tsv")
+        return run_per_donor_analysis(
+            count_file,
+            output,
+            unit=unit,
+            model="single" if model is None else model,
+            dispersion_scope=dispersion_scope,
+            region_col=region_col,
+            phased=bool(phased),
+            min_count=10 if min_count is None else min_count,
+            pseudocount=0 if pseudocount is None else pseudocount,
+            min_donor_observations=min_donor_observations,
+            expected_manifest_sha256=expected_manifest_sha256,
+        )
+
+    if unit is not None:
+        raise ValueError("--unit requires --scope per-donor in the bulk analysis command")
+    if dispersion_scope != "per-donor":
+        raise ValueError("--dispersion-scope requires --scope per-donor")
+    if expected_manifest_sha256 is not None:
+        raise ValueError("--expected-manifest-sha256 requires --scope per-donor")
+
     # Fail closed: --groupby is not supported by the Rust backend. It only re-keys the grouping
     # column (region_col = groupby), so the identical result is obtained with --region_col <parent>.
     # Erroring prevents silently returning feature-level results when parent-level was requested.
@@ -218,3 +271,4 @@ def run_ai_analysis(
 
     # Write results
     ai_df.to_csv(ai_files.out_file, sep="\t", header=True, index=False)
+    return None

--- a/src/analysis/run_analysis_per_donor.py
+++ b/src/analysis/run_analysis_per_donor.py
@@ -1,0 +1,1063 @@
+"""Donor-local allelic imbalance orchestration."""
+
+from __future__ import annotations
+
+import csv
+import gzip
+import hashlib
+import inspect
+import json
+import math
+import os
+import shutil
+import tempfile
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Any, Literal, cast
+
+import pandas as pd
+
+try:
+    from wasp2_rust import analyze_imbalance_run as rust_analyze_imbalance_run
+    from wasp2_rust import fit_imbalance_dispersion as rust_fit_imbalance_dispersion
+except ImportError:
+    rust_analyze_imbalance_run = None
+    rust_fit_imbalance_dispersion = None
+
+AnalysisUnit = Literal["snv", "feature"]
+AnalysisUnitInput = Literal["snv", "feature", "peak"]
+DispersionScope = Literal["global", "per-donor"]
+Model = Literal["single", "linear"]
+
+UTC = timezone.utc
+SCHEMA_VERSION = "wasp2.donor-local-analysis.v1"
+COMMON_COLUMNS = {
+    "donor_id",
+    "chrom",
+    "pos",
+    "ref",
+    "alt",
+    "ref_count",
+    "alt_count",
+}
+SNV_COLUMNS = ["donor_id", "chrom", "pos", "ref", "alt"]
+RUST_RESULT_COLUMNS = [
+    "region",
+    "ref_count",
+    "alt_count",
+    "N",
+    "snp_count",
+    "null_ll",
+    "alt_ll",
+    "mu",
+    "lrt",
+    "pval",
+    "fdr_pval",
+]
+STATISTIC_COLUMNS = [
+    "ref_count",
+    "alt_count",
+    "N",
+    "snp_count",
+    "null_ll",
+    "alt_ll",
+    "mu",
+    "lrt",
+    "pval",
+    "fdr_pval",
+]
+
+
+@dataclass(frozen=True)
+class CountInput:
+    """A verified count table and its optional locked-bundle manifest."""
+
+    counts: Path
+    counts_record: dict[str, str | int]
+    counts_signature: tuple[int, int, int, int]
+    manifest: Path | None
+    manifest_record: dict[str, str | int] | None
+    manifest_signature: tuple[int, int, int, int] | None
+    manifest_data: dict[str, Any] | None
+
+    @property
+    def bundled(self) -> bool:
+        return self.manifest is not None
+
+
+@dataclass(frozen=True)
+class DispersionFit:
+    """Validated nuisance-parameter fit returned by Rust."""
+
+    payload: Mapping[str, Any]
+    fit_id: str
+    method: Model
+    rho: float | None
+    linear_d1: float | None
+    linear_d2: float | None
+    n_observations: int
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _signature(path: Path) -> tuple[int, int, int, int]:
+    stat = path.stat()
+    return stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns
+
+
+def _file_record(path: Path) -> tuple[dict[str, str | int], tuple[int, int, int, int]]:
+    resolved = path.resolve(strict=True)
+    before = _signature(resolved)
+    digest = _sha256(resolved)
+    if _signature(resolved) != before:
+        raise RuntimeError(f"Input changed while it was being hashed: {resolved}")
+    stat = resolved.stat()
+    return (
+        {
+            "path": str(resolved),
+            "sha256": digest,
+            "size_bytes": stat.st_size,
+            "mtime_utc": datetime.fromtimestamp(stat.st_mtime, UTC).isoformat(),
+        },
+        before,
+    )
+
+
+def _package_version() -> str:
+    try:
+        return version("wasp2")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def _normalize_unit(unit: AnalysisUnitInput) -> AnalysisUnit:
+    normalized = "feature" if unit == "peak" else unit
+    if normalized not in {"snv", "feature"}:
+        raise ValueError("unit must be 'snv' or 'feature' ('peak' is an alias)")
+    return cast(AnalysisUnit, normalized)
+
+
+def _validate_sha256(value: str, label: str) -> str:
+    normalized = value.lower()
+    if len(normalized) != 64 or any(
+        character not in "0123456789abcdef" for character in normalized
+    ):
+        raise ValueError(f"{label} must be a 64-character hexadecimal SHA-256 digest")
+    return normalized
+
+
+def _locate_manifest(source: Path) -> Path | None:
+    if source.is_dir():
+        manifest = source / "count_manifest.json"
+        if not manifest.is_file():
+            raise ValueError(f"Count bundle directory has no count_manifest.json: {source}")
+        return manifest
+    if source.name == "count_manifest.json":
+        return source
+    adjacent = source.parent / "count_manifest.json"
+    return adjacent if adjacent.is_file() else None
+
+
+def _resolve_count_input(
+    count_file: str | Path,
+    *,
+    unit: AnalysisUnit,
+    expected_manifest_sha256: str | None,
+) -> CountInput:
+    source = Path(count_file).expanduser()
+    if not source.exists():
+        raise FileNotFoundError(f"Count input does not exist: {source}")
+    source = source.resolve(strict=True)
+    manifest_path = _locate_manifest(source)
+
+    if manifest_path is None:
+        if source.is_dir():
+            raise ValueError(f"Count input is not a regular file: {source}")
+        if expected_manifest_sha256 is not None:
+            raise ValueError(
+                "--expected-manifest-sha256 requires a locked count bundle; "
+                "standalone count tables have no manifest trust anchor"
+            )
+        counts_record, counts_signature = _file_record(source)
+        return CountInput(
+            counts=source,
+            counts_record=counts_record,
+            counts_signature=counts_signature,
+            manifest=None,
+            manifest_record=None,
+            manifest_signature=None,
+            manifest_data=None,
+        )
+
+    from counting.run_counting_cohort import verify_count_bundle
+
+    expected = (
+        _validate_sha256(expected_manifest_sha256, "expected manifest SHA-256")
+        if expected_manifest_sha256 is not None
+        else None
+    )
+    manifest_data = verify_count_bundle(
+        manifest_path,
+        expected_manifest_sha256=expected,
+    )
+    bundle_unit = manifest_data.get("analysis_unit")
+    if bundle_unit != unit:
+        raise ValueError(
+            f"Requested analysis unit {unit!r} does not match locked count bundle unit "
+            f"{bundle_unit!r}"
+        )
+
+    counts_path = (manifest_path.parent / "counts.tsv.gz").resolve(strict=True)
+    if source.is_file() and source != manifest_path.resolve(strict=True) and source != counts_path:
+        raise ValueError(
+            f"Input is inside a count bundle but is not its locked counts table: {source}"
+        )
+    counts_record, counts_signature = _file_record(counts_path)
+    manifest_record, manifest_signature = _file_record(manifest_path)
+    return CountInput(
+        counts=counts_path,
+        counts_record=counts_record,
+        counts_signature=counts_signature,
+        manifest=manifest_path.resolve(strict=True),
+        manifest_record=manifest_record,
+        manifest_signature=manifest_signature,
+        manifest_data=manifest_data,
+    )
+
+
+def _read_header(path: Path) -> list[str]:
+    opener = gzip.open if path.name.endswith(".gz") else open
+    with opener(path, "rt", newline="") as handle:
+        header = next(csv.reader(handle, delimiter="\t"), None)
+    if not header:
+        raise ValueError("Count table is empty or has no header")
+    if any(not column for column in header):
+        raise ValueError("Count table contains an empty column name")
+    duplicate_columns = sorted({column for column in header if header.count(column) > 1})
+    if duplicate_columns:
+        raise ValueError(f"Count table contains duplicate columns: {duplicate_columns}")
+    return header
+
+
+def _coerce_nonnegative_integer(frame: pd.DataFrame, column: str, maximum: int) -> None:
+    values = frame[column].astype(str)
+    valid = values.str.fullmatch(r"[0-9]+")
+    if not valid.all():
+        raise ValueError(f"Column {column!r} contains invalid integer values")
+    integers = values.map(int)
+    if integers.gt(maximum).any():
+        raise ValueError(f"Column {column!r} contains values larger than {maximum}")
+    frame[column] = integers.astype("uint64")
+
+
+def _validate_text_column(frame: pd.DataFrame, column: str) -> None:
+    values = frame[column].astype(str)
+    invalid = values.eq("") | values.str.contains(r"[\t\r\n]", regex=True)
+    if invalid.any():
+        raise ValueError(f"Column {column!r} contains missing, empty, or multiline values")
+    frame[column] = values
+
+
+def _normalize_genotypes(frame: pd.DataFrame) -> dict[str, int]:
+    if "GT" not in frame.columns:
+        raise ValueError("Phased feature analysis requires a GT column")
+    gt = frame["GT"].astype(str)
+    ref = frame["ref"]
+    alt = frame["alt"]
+    numeric_forward = gt.eq("0|1")
+    numeric_reverse = gt.eq("1|0")
+    allele_forward = gt.eq(ref + "|" + alt)
+    allele_reverse = gt.eq(alt + "|" + ref)
+    valid = numeric_forward | numeric_reverse | allele_forward | allele_reverse
+    if not valid.all():
+        bad = frame.loc[~valid, ["donor_id", "chrom", "pos", "ref", "alt", "GT"]].iloc[0]
+        raise ValueError(
+            f"Phased GT must be exact 0|1, 1|0, REF|ALT, or ALT|REF; found {bad.to_dict()}"
+        )
+    forward = numeric_forward | allele_forward
+    frame["GT"] = forward.map({True: "0|1", False: "1|0"})
+    return {
+        "forward": int(forward.sum()),
+        "reverse": int((~forward).sum()),
+        "converted_from_alleles": int((allele_forward | allele_reverse).sum()),
+    }
+
+
+def _first_conflicting_group(
+    frame: pd.DataFrame,
+    identity: Sequence[str],
+    compared: Sequence[str],
+) -> tuple[Any, ...] | None:
+    conflicts = (
+        frame.groupby(list(identity), sort=False, dropna=False)[list(compared)]
+        .nunique(dropna=False)
+        .gt(1)
+        .any(axis=1)
+    )
+    if not conflicts.any():
+        return None
+    key = conflicts.index[conflicts][0]
+    return key if isinstance(key, tuple) else (key,)
+
+
+def _load_counts(
+    count_input: CountInput,
+    *,
+    unit: AnalysisUnit,
+    region_col: str | None,
+    phased: bool,
+) -> tuple[pd.DataFrame, str | None, dict[str, Any]]:
+    header = _read_header(count_input.counts)
+    has_donor_id = "donor_id" in header
+    has_sample = "sample" in header
+    if has_donor_id and has_sample:
+        raise ValueError("Count table cannot contain both donor_id and legacy sample columns")
+    if count_input.bundled and not has_donor_id:
+        raise ValueError("Locked count bundles require the canonical donor_id column")
+    if not has_donor_id and not has_sample:
+        raise ValueError("Count table requires a donor_id column")
+
+    selected_region = region_col
+    if unit == "snv" and region_col is not None:
+        raise ValueError(
+            "SNV analysis tests variants independently and does not accept --region-col"
+        )
+    if unit == "feature":
+        if count_input.bundled and region_col not in {None, "region"}:
+            raise ValueError("Locked feature bundles require the canonical region column")
+        selected_region = "region" if region_col is None and count_input.bundled else region_col
+        if not selected_region:
+            raise ValueError(
+                "Standalone feature analysis requires --region-col; locked feature bundles use region"
+            )
+        if selected_region in COMMON_COLUMNS or selected_region == "sample":
+            raise ValueError(
+                f"Feature region column conflicts with a reserved column: {selected_region}"
+            )
+
+    required = set(COMMON_COLUMNS)
+    if not has_donor_id:
+        required.remove("donor_id")
+        required.add("sample")
+    if selected_region is not None:
+        required.add(selected_region)
+    missing = sorted(required.difference(header))
+    if missing:
+        raise ValueError(f"Count table is missing required columns: {missing}")
+
+    frame = pd.read_csv(
+        count_input.counts,
+        sep="\t",
+        dtype=str,
+        keep_default_na=False,
+        na_filter=False,
+        low_memory=False,
+    )
+    if frame.empty:
+        raise ValueError("Count table contains no observations")
+    if has_sample:
+        frame = frame.rename(columns={"sample": "donor_id"})
+
+    text_columns = ["donor_id", "chrom", "ref", "alt"]
+    if selected_region is not None:
+        text_columns.append(selected_region)
+    for column in text_columns:
+        _validate_text_column(frame, column)
+    for column in ["pos", "ref_count", "alt_count"]:
+        _coerce_nonnegative_integer(frame, column, 2**32 - 1)
+    if frame["pos"].eq(0).any():
+        raise ValueError("SNV positions must be one-based")
+    invalid_alleles = (
+        frame["ref"].eq(frame["alt"])
+        | frame["ref"].str.len().ne(1)
+        | frame["alt"].str.len().ne(1)
+        | frame["alt"].str.contains(",", regex=False)
+    )
+    if invalid_alleles.any():
+        raise ValueError("Donor-local analysis requires biallelic SNV observations")
+
+    site_identity = ["donor_id", "chrom", "pos"]
+    allele_conflict = _first_conflicting_group(frame, site_identity, ["ref", "alt"])
+    if allele_conflict is not None:
+        donor_id, chrom, pos = allele_conflict
+        raise ValueError(f"Conflicting alleles for donor/SNV {donor_id} {chrom}:{pos}")
+
+    gt_qc = _normalize_genotypes(frame) if phased else None
+    repeated_values = ["ref_count", "alt_count"]
+    if phased:
+        repeated_values.append("GT")
+    count_conflict = _first_conflicting_group(frame, SNV_COLUMNS, repeated_values)
+    if count_conflict is not None:
+        donor_id, chrom, pos, ref, alt = count_conflict
+        raise ValueError(
+            f"Conflicting repeated rows for donor/SNV {donor_id} {chrom}:{pos}:{ref}>{alt}"
+        )
+
+    raw_rows = len(frame)
+    identity = [*SNV_COLUMNS, selected_region] if selected_region is not None else SNV_COLUMNS
+    frame = frame.drop_duplicates(identity, keep="first").copy()
+    frame["pos"] = frame["pos"].astype("uint32")
+    frame["ref_count"] = frame["ref_count"].astype("uint32")
+    frame["alt_count"] = frame["alt_count"].astype("uint32")
+    frame["_total_count"] = frame["ref_count"].astype("uint64") + frame["alt_count"].astype(
+        "uint64"
+    )
+    return (
+        frame,
+        selected_region,
+        {
+            "raw_rows": raw_rows,
+            "validated_rows": len(frame),
+            "exact_duplicate_rows_removed": raw_rows - len(frame),
+            "donors": int(frame["donor_id"].nunique()),
+            "unique_donor_snv_rows": int(frame.drop_duplicates(SNV_COLUMNS).shape[0]),
+            "phase": gt_qc,
+            "legacy_sample_normalized": has_sample,
+        },
+    )
+
+
+def _artifact_paths(result_path: Path) -> dict[str, Path]:
+    if result_path.suffix != ".tsv":
+        raise ValueError("Donor-local output must use a .tsv filename")
+    stem = result_path.stem
+    return {
+        "results": result_path,
+        "dispersion": result_path.with_name(f"{stem}.dispersion.tsv"),
+        "qc": result_path.with_name(f"{stem}.qc.tsv"),
+        "provenance": result_path.with_name(f"{stem}.provenance.json"),
+    }
+
+
+def _write_tsv(frame: pd.DataFrame, path: Path, columns: Sequence[str]) -> None:
+    frame.loc[:, list(columns)].to_csv(path, sep="\t", header=True, index=False)
+
+
+def _finite_float(value: Any, label: str) -> float:
+    if isinstance(value, bool):
+        raise RuntimeError(f"Rust returned an invalid {label}")
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as error:
+        raise RuntimeError(f"Rust returned an invalid {label}") from error
+    if not math.isfinite(result):
+        raise RuntimeError(f"Rust returned a non-finite {label}")
+    return result
+
+
+def _validate_fit(raw_fit: Mapping[str, Any], *, model: Model, expected_rows: int) -> DispersionFit:
+    fit_id = raw_fit.get("fit_id")
+    if not isinstance(fit_id, str) or not fit_id:
+        raise RuntimeError("Rust dispersion fit did not return a non-empty fit_id")
+    returned_method = raw_fit.get("method", raw_fit.get("model"))
+    if returned_method != model:
+        raise RuntimeError(
+            f"Rust dispersion fit method {returned_method!r} does not match requested {model!r}"
+        )
+    try:
+        n_observations = int(raw_fit["n_observations"])
+    except (KeyError, TypeError, ValueError) as error:
+        raise RuntimeError("Rust dispersion fit did not return n_observations") from error
+    if n_observations != expected_rows:
+        raise RuntimeError(
+            f"Rust dispersion fit used {n_observations} observations; expected {expected_rows}"
+        )
+
+    if model == "single":
+        rho = _finite_float(raw_fit.get("rho"), "rho")
+        linear_d1 = None
+        linear_d2 = None
+        if raw_fit.get("linear_d1") is not None or raw_fit.get("linear_d2") is not None:
+            raise RuntimeError("Rust single-dispersion fit returned linear parameters")
+    else:
+        rho = None
+        linear_d1 = _finite_float(raw_fit.get("linear_d1"), "linear_d1")
+        linear_d2 = _finite_float(raw_fit.get("linear_d2"), "linear_d2")
+        if raw_fit.get("rho") is not None:
+            raise RuntimeError("Rust linear-dispersion fit returned scalar rho")
+    return DispersionFit(
+        payload=dict(raw_fit),
+        fit_id=fit_id,
+        method=model,
+        rho=rho,
+        linear_d1=linear_d1,
+        linear_d2=linear_d2,
+        n_observations=n_observations,
+    )
+
+
+def _generated_fit_id(
+    path: Path,
+    fit: Mapping[str, Any],
+    *,
+    model: Model,
+    min_count: int,
+    pseudocount: int,
+) -> str:
+    def float_identity(value: Any) -> str | None:
+        return None if value is None else _finite_float(value, "dispersion parameter").hex()
+
+    identity = {
+        "input_sha256": _sha256(path),
+        "method": model,
+        "min_count": min_count,
+        "pseudocount": pseudocount,
+        "rho": float_identity(fit.get("rho")),
+        "linear_d1": float_identity(fit.get("linear_d1")),
+        "linear_d2": float_identity(fit.get("linear_d2")),
+        "n_observations": fit.get("n_observations"),
+    }
+    encoded = json.dumps(identity, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _fit_dispersion(
+    frame: pd.DataFrame,
+    path: Path,
+    *,
+    model: Model,
+    min_count: int,
+    pseudocount: int,
+) -> DispersionFit:
+    fitter = rust_fit_imbalance_dispersion
+    if fitter is None:
+        raise RuntimeError("Rust dispersion-fitting API is not available")
+    fit_columns = [*SNV_COLUMNS, "ref_count", "alt_count"]
+    _write_tsv(frame, path, fit_columns)
+    kwargs: dict[str, Any] = {
+        "min_count": min_count,
+        "pseudocount": pseudocount,
+        "method": model,
+    }
+    try:
+        parameters = inspect.signature(fitter).parameters
+    except (TypeError, ValueError):
+        parameters = {}
+    if "phased" in parameters:
+        kwargs["phased"] = False
+    if "region_col" in parameters:
+        # Rust deduplicates on region. Including donor_id preserves repeated
+        # cohort SNVs as distinct donor-SNV observations in a global fit.
+        kwargs["region_col"] = "donor_id"
+    raw_fit = fitter(str(path), **kwargs)
+    if not isinstance(raw_fit, Mapping):
+        raise RuntimeError("Rust dispersion-fitting API returned an invalid payload")
+    payload = dict(raw_fit)
+    payload.setdefault(
+        "fit_id",
+        _generated_fit_id(
+            path,
+            payload,
+            model=model,
+            min_count=min_count,
+            pseudocount=pseudocount,
+        ),
+    )
+    return _validate_fit(payload, model=model, expected_rows=len(frame))
+
+
+def _call_analyzer_with_fit(
+    path: Path,
+    *,
+    fit: DispersionFit,
+    model: Model,
+    phased: bool,
+    region_col: str | None,
+    min_count: int,
+    pseudocount: int,
+) -> Mapping[str, Any]:
+    analyzer = rust_analyze_imbalance_run
+    if analyzer is None:
+        raise RuntimeError("Rust donor-analysis API is not available")
+    kwargs: dict[str, Any] = {
+        "min_count": min_count,
+        "pseudocount": pseudocount,
+        "phased": phased,
+        "region_col": region_col,
+        "method": model,
+    }
+    try:
+        parameters = inspect.signature(analyzer).parameters
+    except (TypeError, ValueError):
+        parameters = {}
+    accepts_keywords = any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters.values()
+    )
+    explicit_fixed_parameters = {"rho", "linear_d1", "linear_d2"}.issubset(parameters)
+    if "dispersion_fit" in parameters or (accepts_keywords and not explicit_fixed_parameters):
+        kwargs["dispersion_fit"] = fit.payload
+        run = analyzer(str(path), **kwargs)
+    elif explicit_fixed_parameters:
+        kwargs.update(
+            {
+                "rho": fit.rho,
+                "linear_d1": fit.linear_d1,
+                "linear_d2": fit.linear_d2,
+            }
+        )
+        if "exact_snv" in parameters:
+            kwargs["exact_snv"] = region_col is None
+        raw_run = analyzer(str(path), **kwargs)
+        if not isinstance(raw_run, Mapping):
+            raise RuntimeError("Rust donor-analysis API returned an invalid payload")
+        returned_parameters = (
+            raw_run.get("rho"),
+            raw_run.get("linear_d1"),
+            raw_run.get("linear_d2"),
+        )
+        if returned_parameters != (fit.rho, fit.linear_d1, fit.linear_d2):
+            raise RuntimeError("Rust donor-analysis API changed the fixed dispersion parameters")
+        if raw_run.get("nuisance_source") not in {None, "fixed"}:
+            raise RuntimeError(
+                "Rust donor-analysis API refitted the supplied dispersion parameters"
+            )
+        run = {**raw_run, "dispersion_fit": fit.payload}
+    else:
+        raise RuntimeError("Rust donor-analysis API cannot accept a reusable dispersion fit")
+    if not isinstance(run, Mapping):
+        raise RuntimeError("Rust donor-analysis API returned an invalid payload")
+    return run
+
+
+def _run_fit_values(run: Mapping[str, Any]) -> tuple[Any, Any, Any, Any]:
+    nested = run.get("dispersion_fit")
+    source = nested if isinstance(nested, Mapping) else run
+    fit_id = source.get("fit_id", source.get("dispersion_fit_id"))
+    return fit_id, source.get("rho"), source.get("linear_d1"), source.get("linear_d2")
+
+
+def _require_exact_fit_echo(run: Mapping[str, Any], fit: DispersionFit, donor_id: str) -> None:
+    observed = _run_fit_values(run)
+    expected = (fit.fit_id, fit.rho, fit.linear_d1, fit.linear_d2)
+    if observed != expected:
+        raise RuntimeError(
+            f"Rust donor run for {donor_id} did not reuse the requested dispersion fit exactly: "
+            f"expected {expected!r}, observed {observed!r}"
+        )
+
+
+def _validate_rust_results(run: Mapping[str, Any], donor_id: str) -> pd.DataFrame:
+    raw_results = run.get("results")
+    if not isinstance(raw_results, list) or not raw_results:
+        raise RuntimeError(f"Rust returned no results for included donor {donor_id}")
+    results = pd.DataFrame(raw_results)
+    missing = sorted(set(RUST_RESULT_COLUMNS).difference(results.columns))
+    if missing:
+        raise RuntimeError(f"Rust results for {donor_id} are missing columns: {missing}")
+    if results["region"].astype(str).duplicated().any():
+        raise RuntimeError(f"Rust returned duplicate result identities for donor {donor_id}")
+    return results.loc[:, RUST_RESULT_COLUMNS].copy()
+
+
+def _prepare_analysis_table(
+    donor_frame: pd.DataFrame,
+    path: Path,
+    *,
+    unit: AnalysisUnit,
+    region_col: str | None,
+    phased: bool,
+) -> tuple[str | None, pd.DataFrame]:
+    columns = ["chrom", "pos", "ref", "alt"]
+    rust_region_col = None
+    if phased:
+        columns.append("GT")
+    if unit == "feature":
+        if region_col is None:
+            raise RuntimeError("Feature analysis has no normalized region column")
+        columns.append(region_col)
+        rust_region_col = region_col
+    columns.extend(["ref_count", "alt_count"])
+    _write_tsv(donor_frame, path, columns)
+    return rust_region_col, donor_frame
+
+
+def _format_donor_results(
+    run: Mapping[str, Any],
+    donor_frame: pd.DataFrame,
+    *,
+    donor_id: str,
+    unit: AnalysisUnit,
+    region_col: str | None,
+) -> pd.DataFrame:
+    results = _validate_rust_results(run, donor_id)
+    try:
+        n_observations = int(run["n_observations"])
+    except (KeyError, TypeError, ValueError) as error:
+        raise RuntimeError(f"Rust donor run for {donor_id} omitted n_observations") from error
+    if n_observations != len(donor_frame):
+        raise RuntimeError(
+            f"Rust donor run for {donor_id} used {n_observations} rows; expected {len(donor_frame)}"
+        )
+
+    if unit == "snv":
+        annotations = donor_frame.loc[
+            :, ["chrom", "pos", "ref", "alt", "ref_count", "alt_count"]
+        ].rename(
+            columns={
+                "ref_count": "expected_ref_count",
+                "alt_count": "expected_alt_count",
+            }
+        )
+        annotations["region"] = annotations["chrom"] + "_" + annotations["pos"].astype(str)
+        annotations["snv_id"] = (
+            annotations["chrom"]
+            + ":"
+            + annotations["pos"].astype(str)
+            + ":"
+            + annotations["ref"]
+            + ":"
+            + annotations["alt"]
+        )
+        results = annotations.merge(results, on="region", how="inner", validate="one_to_one")
+        if len(results) != len(annotations):
+            raise RuntimeError(f"Rust omitted eligible SNV results for donor {donor_id}")
+        mismatch = (
+            results["ref_count"].ne(results["expected_ref_count"])
+            | results["alt_count"].ne(results["expected_alt_count"])
+            | results["N"].ne(results["expected_ref_count"] + results["expected_alt_count"])
+            | results["snp_count"].ne(1)
+        )
+        if mismatch.any():
+            raise RuntimeError(f"Rust SNV counts differ from input for donor {donor_id}")
+        leading_columns = ["donor_id", "snv_id", "chrom", "pos", "ref", "alt"]
+        results = results.drop(columns=["region", "expected_ref_count", "expected_alt_count"])
+    else:
+        if region_col is None:
+            raise RuntimeError("Feature analysis has no normalized region column")
+        expected = (
+            donor_frame.groupby(region_col, sort=False)
+            .agg(
+                expected_ref_count=("ref_count", "sum"),
+                expected_alt_count=("alt_count", "sum"),
+                expected_snp_count=("pos", "size"),
+            )
+            .reset_index()
+            .rename(columns={region_col: "region"})
+        )
+        results = expected.merge(results, on="region", how="inner", validate="one_to_one")
+        if len(results) != len(expected):
+            raise RuntimeError(f"Rust omitted eligible feature results for donor {donor_id}")
+        mismatch = (
+            results["ref_count"].ne(results["expected_ref_count"])
+            | results["alt_count"].ne(results["expected_alt_count"])
+            | results["snp_count"].ne(results["expected_snp_count"])
+        )
+        if mismatch.any():
+            raise RuntimeError(f"Rust feature aggregation differs from input for donor {donor_id}")
+        results = results.drop(
+            columns=["expected_ref_count", "expected_alt_count", "expected_snp_count"]
+        ).rename(columns={"region": "feature_id"})
+        leading_columns = ["donor_id", "feature_id"]
+
+    results.insert(0, "donor_id", donor_id)
+    results["significant_q05"] = results["fdr_pval"] < 0.05
+    results["significant_q10"] = results["fdr_pval"] < 0.10
+    return results.loc[
+        :, [*leading_columns, *STATISTIC_COLUMNS, "significant_q05", "significant_q10"]
+    ]
+
+
+def _fsync_file(path: Path) -> None:
+    with path.open("rb") as handle:
+        os.fsync(handle.fileno())
+
+
+def _fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _same_inode(left: Path, right: Path) -> bool:
+    try:
+        left_stat = left.stat()
+        right_stat = right.stat()
+    except FileNotFoundError:
+        return False
+    return (left_stat.st_dev, left_stat.st_ino) == (right_stat.st_dev, right_stat.st_ino)
+
+
+def _publish_no_replace(staged: Mapping[str, Path], destinations: Mapping[str, Path]) -> None:
+    """Publish sidecars first and the result commit marker last without clobbering."""
+
+    published: list[tuple[Path, Path]] = []
+    try:
+        for name in ["dispersion", "qc", "provenance", "results"]:
+            source = staged[name]
+            destination = destinations[name]
+            os.link(source, destination, follow_symlinks=False)
+            published.append((source, destination))
+        _fsync_directory(destinations["results"].parent)
+    except BaseException:
+        for source, destination in reversed(published):
+            if _same_inode(source, destination):
+                destination.unlink()
+        _fsync_directory(destinations["results"].parent)
+        raise
+
+
+def _require_unchanged(count_input: CountInput) -> None:
+    if _signature(count_input.counts) != count_input.counts_signature:
+        raise RuntimeError("Count input changed while donor-local analysis was running")
+    if count_input.counts_record["sha256"] != _sha256(count_input.counts):
+        raise RuntimeError("Count input content changed while donor-local analysis was running")
+    if count_input.manifest is not None:
+        if count_input.manifest_signature is None or count_input.manifest_record is None:
+            raise RuntimeError("Internal error: bundle manifest lock is incomplete")
+        if _signature(count_input.manifest) != count_input.manifest_signature:
+            raise RuntimeError("Count manifest changed while donor-local analysis was running")
+        if count_input.manifest_record["sha256"] != _sha256(count_input.manifest):
+            raise RuntimeError(
+                "Count manifest content changed while donor-local analysis was running"
+            )
+
+
+def run_per_donor_analysis(
+    count_file: str | Path,
+    out_file: str | Path,
+    *,
+    unit: AnalysisUnitInput,
+    model: Model = "single",
+    dispersion_scope: DispersionScope = "per-donor",
+    region_col: str | None = None,
+    phased: bool = False,
+    min_count: int = 10,
+    pseudocount: int = 0,
+    min_donor_observations: int = 50,
+    expected_manifest_sha256: str | None = None,
+) -> dict[str, Path]:
+    """Run independent donor tests with an explicit reusable dispersion fit."""
+
+    normalized_unit = _normalize_unit(unit)
+    if model not in {"single", "linear"}:
+        raise ValueError("model must be 'single' or 'linear'")
+    if dispersion_scope not in {"global", "per-donor"}:
+        raise ValueError("dispersion_scope must be 'global' or 'per-donor'")
+    if min_count < 0 or pseudocount < 0:
+        raise ValueError("min_count and pseudocount must be nonnegative")
+    if min_donor_observations < 1:
+        raise ValueError("min_donor_observations must be positive")
+    if normalized_unit == "snv" and phased:
+        raise ValueError("Per-donor SNV analysis is unphased; --phased is not valid")
+
+    count_input = _resolve_count_input(
+        count_file,
+        unit=normalized_unit,
+        expected_manifest_sha256=expected_manifest_sha256,
+    )
+    frame, normalized_region_col, input_qc = _load_counts(
+        count_input,
+        unit=normalized_unit,
+        region_col=region_col,
+        phased=phased,
+    )
+
+    result_path = Path(os.path.abspath(Path(out_file).expanduser()))
+    paths = _artifact_paths(result_path)
+    if not result_path.parent.is_dir():
+        raise ValueError(f"Output parent directory does not exist: {result_path.parent}")
+    existing = [str(path) for path in paths.values() if os.path.lexists(path)]
+    if existing:
+        raise FileExistsError(f"Refusing to overwrite donor-local analysis artifacts: {existing}")
+    if rust_fit_imbalance_dispersion is None or rust_analyze_imbalance_run is None:
+        raise RuntimeError(
+            "Rust donor-local analysis APIs are not available. Build the extension with "
+            "`maturin develop --release` in the WASP2 environment."
+        )
+
+    eligible_rows = frame.loc[frame["_total_count"] >= min_count].copy()
+    fit_rows = (
+        eligible_rows.drop_duplicates(SNV_COLUMNS, keep="first")
+        .sort_values(SNV_COLUMNS, kind="mergesort")
+        .copy()
+    )
+    donor_qc = (
+        frame.groupby("donor_id", sort=True)
+        .agg(
+            input_rows=("donor_id", "size"),
+            unique_snv_rows=("pos", "size"),
+        )
+        .reset_index()
+    )
+    unique_snv_counts = (
+        frame.drop_duplicates(SNV_COLUMNS)
+        .groupby("donor_id", sort=True)
+        .size()
+        .rename("unique_snv_rows")
+    )
+    eligible_counts = (
+        fit_rows.groupby("donor_id", sort=True).size().rename("eligible_snv_observations")
+    )
+    eligible_test_rows = (
+        eligible_rows.groupby("donor_id", sort=True).size().rename("eligible_test_rows")
+    )
+    donor_qc = donor_qc.drop(columns="unique_snv_rows").join(unique_snv_counts, on="donor_id")
+    donor_qc = donor_qc.join(eligible_counts, on="donor_id").join(eligible_test_rows, on="donor_id")
+    donor_qc[["eligible_snv_observations", "eligible_test_rows"]] = (
+        donor_qc[["eligible_snv_observations", "eligible_test_rows"]].fillna(0).astype(int)
+    )
+    donor_qc["analyzed"] = donor_qc["eligible_snv_observations"] >= min_donor_observations
+    donor_qc["status"] = donor_qc["analyzed"].map(
+        {True: "included", False: "excluded_min_observations"}
+    )
+    included_donors = donor_qc.loc[donor_qc["analyzed"], "donor_id"].tolist()
+    if not included_donors:
+        raise RuntimeError("No donors met the minimum eligible-SNV observation requirement")
+
+    eligible_rows = eligible_rows.loc[eligible_rows["donor_id"].isin(included_donors)].copy()
+    fit_rows = fit_rows.loc[fit_rows["donor_id"].isin(included_donors)].copy()
+    staging = Path(tempfile.mkdtemp(prefix=f".{result_path.stem}.staging-", dir=result_path.parent))
+    work = staging / "_work"
+    work.mkdir()
+    try:
+        global_fit = None
+        if dispersion_scope == "global":
+            global_fit = _fit_dispersion(
+                fit_rows,
+                work / "global_fit.tsv",
+                model=model,
+                min_count=min_count,
+                pseudocount=pseudocount,
+            )
+
+        result_frames: list[pd.DataFrame] = []
+        dispersion_rows: list[dict[str, Any]] = []
+        for donor_id in included_donors:
+            donor_id = str(donor_id)
+            donor_rows = eligible_rows.loc[eligible_rows["donor_id"] == donor_id].copy()
+            donor_fit_rows = fit_rows.loc[fit_rows["donor_id"] == donor_id].copy()
+            fit = global_fit or _fit_dispersion(
+                donor_fit_rows,
+                work / "donor_fit.tsv",
+                model=model,
+                min_count=min_count,
+                pseudocount=pseudocount,
+            )
+            rust_region_col, donor_rows = _prepare_analysis_table(
+                donor_rows,
+                work / "donor_counts.tsv",
+                unit=normalized_unit,
+                region_col=normalized_region_col,
+                phased=phased,
+            )
+            run = _call_analyzer_with_fit(
+                work / "donor_counts.tsv",
+                fit=fit,
+                model=model,
+                phased=phased,
+                region_col=rust_region_col,
+                min_count=min_count,
+                pseudocount=pseudocount,
+            )
+            _require_exact_fit_echo(run, fit, donor_id)
+            if bool(run.get("requested_phased")) != phased:
+                raise RuntimeError(f"Rust donor run for {donor_id} changed requested_phased")
+            if phased and not bool(run.get("effective_phased")):
+                raise RuntimeError(f"Rust silently fell back to unphased analysis for {donor_id}")
+            donor_results = _format_donor_results(
+                run,
+                donor_rows,
+                donor_id=donor_id,
+                unit=normalized_unit,
+                region_col=normalized_region_col,
+            )
+            result_frames.append(donor_results)
+            dispersion_rows.append(
+                {
+                    "donor_id": donor_id,
+                    "dispersion_scope": dispersion_scope,
+                    "fit_id": fit.fit_id,
+                    "model": model,
+                    "rho": fit.rho,
+                    "linear_d1": fit.linear_d1,
+                    "linear_d2": fit.linear_d2,
+                    "fit_observations": fit.n_observations,
+                    "donor_eligible_snv_observations": len(donor_fit_rows),
+                    "result_rows": len(donor_results),
+                }
+            )
+
+        _require_unchanged(count_input)
+        sort_columns = (
+            ["donor_id", "snv_id"]
+            if normalized_unit == "snv"
+            else [
+                "donor_id",
+                "feature_id",
+            ]
+        )
+        results = pd.concat(result_frames, ignore_index=True).sort_values(
+            sort_columns, kind="mergesort"
+        )
+        dispersion = pd.DataFrame(dispersion_rows).sort_values("donor_id", kind="mergesort")
+        qc = donor_qc.sort_values("donor_id", kind="mergesort")
+
+        staged_paths = {name: staging / path.name for name, path in paths.items()}
+        results.to_csv(staged_paths["results"], sep="\t", header=True, index=False)
+        dispersion.to_csv(staged_paths["dispersion"], sep="\t", header=True, index=False)
+        qc.to_csv(staged_paths["qc"], sep="\t", header=True, index=False)
+        for name in ["results", "dispersion", "qc"]:
+            _fsync_file(staged_paths[name])
+
+        output_records: dict[str, dict[str, str | int]] = {}
+        for name in ["results", "dispersion", "qc"]:
+            record, _ = _file_record(staged_paths[name])
+            output_records[name] = {**record, "path": paths[name].name}
+        provenance = {
+            "schema_version": SCHEMA_VERSION,
+            "created_at_utc": datetime.now(UTC).isoformat(),
+            "software": {"package": "wasp2", "version": _package_version()},
+            "analysis": {
+                "scope": "per-donor",
+                "unit": normalized_unit,
+                "model": model,
+                "dispersion_scope": dispersion_scope,
+                "region_col": normalized_region_col,
+                "phased": phased,
+                "multiple_testing": "Benjamini-Hochberg independently within each donor",
+            },
+            "parameters": {
+                "min_count": min_count,
+                "pseudocount": pseudocount,
+                "min_donor_observations": min_donor_observations,
+            },
+            "inputs": {
+                "counts": count_input.counts_record,
+                "count_manifest": count_input.manifest_record,
+                "count_bundle_schema": (
+                    count_input.manifest_data.get("schema_version")
+                    if count_input.manifest_data is not None
+                    else None
+                ),
+                "qc": input_qc,
+            },
+            "donors": {
+                "total": len(qc),
+                "included": int(qc["analyzed"].sum()),
+                "excluded": int((~qc["analyzed"]).sum()),
+            },
+            "outputs": output_records,
+        }
+        staged_paths["provenance"].write_text(
+            json.dumps(provenance, indent=2, sort_keys=True) + "\n"
+        )
+        _fsync_file(staged_paths["provenance"])
+        _fsync_directory(staging)
+        _require_unchanged(count_input)
+        _publish_no_replace(staged_paths, paths)
+        shutil.rmtree(staging, ignore_errors=True)
+        return paths
+    except BaseException:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise

--- a/src/analysis/run_analysis_per_donor.py
+++ b/src/analysis/run_analysis_per_donor.py
@@ -31,9 +31,10 @@ AnalysisUnit = Literal["snv", "feature"]
 AnalysisUnitInput = Literal["snv", "feature", "peak"]
 DispersionScope = Literal["global", "per-donor"]
 Model = Literal["single", "linear"]
+FitMetadataValue = str | int | float | bool | None
 
 UTC = timezone.utc
-SCHEMA_VERSION = "wasp2.donor-local-analysis.v1"
+SCHEMA_VERSION = "wasp2.donor-local-analysis.v2"
 COMMON_COLUMNS = {
     "donor_id",
     "chrom",
@@ -98,7 +99,11 @@ class DispersionFit:
     rho: float | None
     linear_d1: float | None
     linear_d2: float | None
+    linear_depth_center: float | None
+    linear_depth_scale: float | None
     n_observations: int
+    metadata: Mapping[str, FitMetadataValue]
+    extended_contract: bool
 
 
 def _sha256(path: Path) -> str:
@@ -319,6 +324,7 @@ def _load_counts(
     header = _read_header(count_input.counts)
     has_donor_id = "donor_id" in header
     has_sample = "sample" in header
+    has_snv_id = "snv_id" in header
     if has_donor_id and has_sample:
         raise ValueError("Count table cannot contain both donor_id and legacy sample columns")
     if count_input.bundled and not has_donor_id:
@@ -339,7 +345,7 @@ def _load_counts(
             raise ValueError(
                 "Standalone feature analysis requires --region-col; locked feature bundles use region"
             )
-        if selected_region in COMMON_COLUMNS or selected_region == "sample":
+        if selected_region in COMMON_COLUMNS or selected_region in {"sample", "snv_id"}:
             raise ValueError(
                 f"Feature region column conflicts with a reserved column: {selected_region}"
             )
@@ -368,6 +374,8 @@ def _load_counts(
         frame = frame.rename(columns={"sample": "donor_id"})
 
     text_columns = ["donor_id", "chrom", "ref", "alt"]
+    if has_snv_id:
+        text_columns.append("snv_id")
     if selected_region is not None:
         text_columns.append(selected_region)
     for column in text_columns:
@@ -390,6 +398,32 @@ def _load_counts(
     if allele_conflict is not None:
         donor_id, chrom, pos = allele_conflict
         raise ValueError(f"Conflicting alleles for donor/SNV {donor_id} {chrom}:{pos}")
+
+    if has_snv_id:
+        snv_id_conflict = _first_conflicting_group(
+            frame,
+            ["donor_id", "snv_id"],
+            ["chrom", "pos", "ref", "alt"],
+        )
+        if snv_id_conflict is not None:
+            donor_id, snv_id = snv_id_conflict
+            raise ValueError(f"snv_id {snv_id!r} maps to conflicting variants for donor {donor_id}")
+        identity_conflict = _first_conflicting_group(frame, SNV_COLUMNS, ["snv_id"])
+        if identity_conflict is not None:
+            donor_id, chrom, pos, ref, alt = identity_conflict
+            raise ValueError(
+                f"Multiple snv_id values map to donor/SNV {donor_id} {chrom}:{pos}:{ref}>{alt}"
+            )
+    else:
+        frame["snv_id"] = (
+            frame["chrom"]
+            + ":"
+            + frame["pos"].astype(str)
+            + ":"
+            + frame["ref"]
+            + ":"
+            + frame["alt"]
+        )
 
     gt_qc = _normalize_genotypes(frame) if phased else None
     repeated_values = ["ref_count", "alt_count"]
@@ -422,6 +456,7 @@ def _load_counts(
             "unique_donor_snv_rows": int(frame.drop_duplicates(SNV_COLUMNS).shape[0]),
             "phase": gt_qc,
             "legacy_sample_normalized": has_sample,
+            "snv_id_source": "input" if has_snv_id else "synthesized",
         },
     )
 
@@ -454,7 +489,41 @@ def _finite_float(value: Any, label: str) -> float:
     return result
 
 
-def _validate_fit(raw_fit: Mapping[str, Any], *, model: Model, expected_rows: int) -> DispersionFit:
+def _fit_metadata(
+    raw_fit: Mapping[str, Any], *, add_parameters_returned_status: bool
+) -> dict[str, FitMetadataValue]:
+    metadata: dict[str, FitMetadataValue] = {}
+    for name, value in raw_fit.items():
+        if name != "fit_status" and name != "optimizer" and not name.startswith("optimizer_"):
+            continue
+        if value is None:
+            continue
+        if isinstance(value, str):
+            if not value or any(character in value for character in "\t\r\n"):
+                raise RuntimeError(f"Rust returned an invalid {name}")
+            metadata[name] = value
+        elif isinstance(value, (bool, int)):
+            metadata[name] = value
+        elif isinstance(value, float):
+            if not math.isfinite(value):
+                raise RuntimeError(f"Rust returned a non-finite {name}")
+            metadata[name] = value
+        else:
+            raise RuntimeError(f"Rust returned a non-scalar {name}")
+    if add_parameters_returned_status and "fit_status" not in metadata:
+        # The API currently proves that parameters were returned, but does not
+        # expose optimizer convergence diagnostics.
+        metadata["fit_status"] = "parameters_returned"
+    return metadata
+
+
+def _validate_fit(
+    raw_fit: Mapping[str, Any],
+    *,
+    model: Model,
+    expected_rows: int,
+    allow_legacy_linear_mock: bool = False,
+) -> DispersionFit:
     fit_id = raw_fit.get("fit_id")
     if not isinstance(fit_id, str) or not fit_id:
         raise RuntimeError("Rust dispersion fit did not return a non-empty fit_id")
@@ -476,14 +545,47 @@ def _validate_fit(raw_fit: Mapping[str, Any], *, model: Model, expected_rows: in
         rho = _finite_float(raw_fit.get("rho"), "rho")
         linear_d1 = None
         linear_d2 = None
-        if raw_fit.get("linear_d1") is not None or raw_fit.get("linear_d2") is not None:
+        linear_depth_center = None
+        linear_depth_scale = None
+        linear_values = (
+            raw_fit.get("linear_d1"),
+            raw_fit.get("linear_d2"),
+            raw_fit.get("linear_depth_center"),
+            raw_fit.get("linear_depth_scale"),
+        )
+        if any(value is not None for value in linear_values):
             raise RuntimeError("Rust single-dispersion fit returned linear parameters")
+        extended_contract = True
     else:
         rho = None
         linear_d1 = _finite_float(raw_fit.get("linear_d1"), "linear_d1")
         linear_d2 = _finite_float(raw_fit.get("linear_d2"), "linear_d2")
         if raw_fit.get("rho") is not None:
             raise RuntimeError("Rust linear-dispersion fit returned scalar rho")
+        raw_center = raw_fit.get("linear_depth_center")
+        raw_scale = raw_fit.get("linear_depth_scale")
+        if (raw_center is None) != (raw_scale is None):
+            raise RuntimeError(
+                "Rust linear-dispersion fit returned incomplete depth standardization"
+            )
+        if raw_center is None:
+            if not allow_legacy_linear_mock:
+                raise RuntimeError(
+                    "Rust linear-dispersion fit omitted linear_depth_center and linear_depth_scale"
+                )
+            linear_depth_center = None
+            linear_depth_scale = None
+            extended_contract = False
+        else:
+            linear_depth_center = _finite_float(raw_center, "linear_depth_center")
+            linear_depth_scale = _finite_float(raw_scale, "linear_depth_scale")
+            if linear_depth_scale <= 0:
+                raise RuntimeError("Rust returned a non-positive linear_depth_scale")
+            extended_contract = True
+    metadata = _fit_metadata(
+        raw_fit,
+        add_parameters_returned_status=extended_contract,
+    )
     return DispersionFit(
         payload=dict(raw_fit),
         fit_id=fit_id,
@@ -491,7 +593,11 @@ def _validate_fit(raw_fit: Mapping[str, Any], *, model: Model, expected_rows: in
         rho=rho,
         linear_d1=linear_d1,
         linear_d2=linear_d2,
+        linear_depth_center=linear_depth_center,
+        linear_depth_scale=linear_depth_scale,
         n_observations=n_observations,
+        metadata=metadata,
+        extended_contract=extended_contract,
     )
 
 
@@ -514,6 +620,8 @@ def _generated_fit_id(
         "rho": float_identity(fit.get("rho")),
         "linear_d1": float_identity(fit.get("linear_d1")),
         "linear_d2": float_identity(fit.get("linear_d2")),
+        "linear_depth_center": float_identity(fit.get("linear_depth_center")),
+        "linear_depth_scale": float_identity(fit.get("linear_depth_scale")),
         "n_observations": fit.get("n_observations"),
     }
     encoded = json.dumps(identity, sort_keys=True, separators=(",", ":")).encode()
@@ -533,22 +641,24 @@ def _fit_dispersion(
         raise RuntimeError("Rust dispersion-fitting API is not available")
     fit_columns = [*SNV_COLUMNS, "ref_count", "alt_count"]
     _write_tsv(frame, path, fit_columns)
-    kwargs: dict[str, Any] = {
+    base_kwargs: dict[str, Any] = {
         "min_count": min_count,
         "pseudocount": pseudocount,
         "method": model,
     }
-    try:
+    full_kwargs = {**base_kwargs, "phased": False, "region_col": "donor_id"}
+    is_pyo3 = _is_known_pyo3_api(fitter)
+    if is_pyo3:
+        # donor_id is part of the fit identity. This is essential for a global
+        # fit because the same genomic site in two donors is two observations.
+        raw_fit = fitter(str(path), **full_kwargs)
+    else:
         parameters = inspect.signature(fitter).parameters
-    except (TypeError, ValueError):
-        parameters = {}
-    if "phased" in parameters:
-        kwargs["phased"] = False
-    if "region_col" in parameters:
-        # Rust deduplicates on region. Including donor_id preserves repeated
-        # cohort SNVs as distinct donor-SNV observations in a global fit.
-        kwargs["region_col"] = "donor_id"
-    raw_fit = fitter(str(path), **kwargs)
+        accepts_keywords = any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters.values()
+        )
+        supports_full_call = accepts_keywords or {"phased", "region_col"}.issubset(parameters)
+        raw_fit = fitter(str(path), **(full_kwargs if supports_full_call else base_kwargs))
     if not isinstance(raw_fit, Mapping):
         raise RuntimeError("Rust dispersion-fitting API returned an invalid payload")
     payload = dict(raw_fit)
@@ -562,7 +672,34 @@ def _fit_dispersion(
             pseudocount=pseudocount,
         ),
     )
-    return _validate_fit(payload, model=model, expected_rows=len(frame))
+    return _validate_fit(
+        payload,
+        model=model,
+        expected_rows=len(frame),
+        allow_legacy_linear_mock=not is_pyo3,
+    )
+
+
+def _is_known_pyo3_api(callback: Any) -> bool:
+    module = getattr(callback, "__module__", "")
+    return module == "wasp2_rust" or module.startswith("wasp2_rust.")
+
+
+def _parameter_values(source: Mapping[str, Any]) -> tuple[Any, Any, Any, Any, Any]:
+    return (
+        source.get("rho"),
+        source.get("linear_d1"),
+        source.get("linear_d2"),
+        source.get("linear_depth_center"),
+        source.get("linear_depth_scale"),
+    )
+
+
+def _parameter_identity(values: Sequence[Any]) -> tuple[str | None, ...]:
+    return tuple(
+        None if value is None else _finite_float(value, "dispersion parameter").hex()
+        for value in values
+    )
 
 
 def _call_analyzer_with_fit(
@@ -578,67 +715,71 @@ def _call_analyzer_with_fit(
     analyzer = rust_analyze_imbalance_run
     if analyzer is None:
         raise RuntimeError("Rust donor-analysis API is not available")
-    kwargs: dict[str, Any] = {
+    base_kwargs: dict[str, Any] = {
         "min_count": min_count,
         "pseudocount": pseudocount,
         "phased": phased,
         "region_col": region_col,
         "method": model,
     }
-    try:
-        parameters = inspect.signature(analyzer).parameters
-    except (TypeError, ValueError):
-        parameters = {}
-    accepts_keywords = any(
-        parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters.values()
-    )
-    explicit_fixed_parameters = {"rho", "linear_d1", "linear_d2"}.issubset(parameters)
-    if "dispersion_fit" in parameters or (accepts_keywords and not explicit_fixed_parameters):
-        kwargs["dispersion_fit"] = fit.payload
-        run = analyzer(str(path), **kwargs)
-    elif explicit_fixed_parameters:
-        kwargs.update(
-            {
-                "rho": fit.rho,
-                "linear_d1": fit.linear_d1,
-                "linear_d2": fit.linear_d2,
-            }
-        )
-        if "exact_snv" in parameters:
-            kwargs["exact_snv"] = region_col is None
-        raw_run = analyzer(str(path), **kwargs)
-        if not isinstance(raw_run, Mapping):
-            raise RuntimeError("Rust donor-analysis API returned an invalid payload")
-        returned_parameters = (
-            raw_run.get("rho"),
-            raw_run.get("linear_d1"),
-            raw_run.get("linear_d2"),
-        )
-        if returned_parameters != (fit.rho, fit.linear_d1, fit.linear_d2):
-            raise RuntimeError("Rust donor-analysis API changed the fixed dispersion parameters")
-        if raw_run.get("nuisance_source") not in {None, "fixed"}:
-            raise RuntimeError(
-                "Rust donor-analysis API refitted the supplied dispersion parameters"
-            )
-        run = {**raw_run, "dispersion_fit": fit.payload}
+    explicit_kwargs = {
+        **base_kwargs,
+        "rho": fit.rho,
+        "linear_d1": fit.linear_d1,
+        "linear_d2": fit.linear_d2,
+        "linear_depth_center": fit.linear_depth_center,
+        "linear_depth_scale": fit.linear_depth_scale,
+        "exact_snv": region_col is None,
+    }
+    if _is_known_pyo3_api(analyzer):
+        raw_run = analyzer(str(path), **explicit_kwargs)
     else:
-        raise RuntimeError("Rust donor-analysis API cannot accept a reusable dispersion fit")
+        parameters = inspect.signature(analyzer).parameters
+        if "dispersion_fit" in parameters or not {
+            "rho",
+            "linear_d1",
+            "linear_d2",
+        }.intersection(parameters):
+            run = analyzer(str(path), **base_kwargs, dispersion_fit=fit.payload)
+            if not isinstance(run, Mapping):
+                raise RuntimeError("Rust donor-analysis API returned an invalid payload")
+            return run
+        raw_run = analyzer(str(path), **explicit_kwargs)
+
+    if not isinstance(raw_run, Mapping):
+        raise RuntimeError("Rust donor-analysis API returned an invalid payload")
+    if _parameter_identity(_parameter_values(raw_run)) != _parameter_identity(
+        _parameter_values(fit.payload)
+    ):
+        raise RuntimeError("Rust donor-analysis API changed the fixed dispersion parameters")
+    if raw_run.get("nuisance_source") not in {None, "fixed"}:
+        raise RuntimeError("Rust donor-analysis API refitted the supplied dispersion parameters")
+    run = {**raw_run, "dispersion_fit": fit.payload}
     if not isinstance(run, Mapping):
         raise RuntimeError("Rust donor-analysis API returned an invalid payload")
     return run
 
 
-def _run_fit_values(run: Mapping[str, Any]) -> tuple[Any, Any, Any, Any]:
+def _run_fit_values(run: Mapping[str, Any]) -> tuple[Any, Any, Any, Any, Any, Any]:
     nested = run.get("dispersion_fit")
     source = nested if isinstance(nested, Mapping) else run
     fit_id = source.get("fit_id", source.get("dispersion_fit_id"))
-    return fit_id, source.get("rho"), source.get("linear_d1"), source.get("linear_d2")
+    return fit_id, *_parameter_values(source)
 
 
 def _require_exact_fit_echo(run: Mapping[str, Any], fit: DispersionFit, donor_id: str) -> None:
     observed = _run_fit_values(run)
-    expected = (fit.fit_id, fit.rho, fit.linear_d1, fit.linear_d2)
-    if observed != expected:
+    expected = (
+        fit.fit_id,
+        fit.rho,
+        fit.linear_d1,
+        fit.linear_d2,
+        fit.linear_depth_center,
+        fit.linear_depth_scale,
+    )
+    if observed[0] != expected[0] or _parameter_identity(observed[1:]) != _parameter_identity(
+        expected[1:]
+    ):
         raise RuntimeError(
             f"Rust donor run for {donor_id} did not reuse the requested dispersion fit exactly: "
             f"expected {expected!r}, observed {observed!r}"
@@ -700,7 +841,7 @@ def _format_donor_results(
 
     if unit == "snv":
         annotations = donor_frame.loc[
-            :, ["chrom", "pos", "ref", "alt", "ref_count", "alt_count"]
+            :, ["snv_id", "chrom", "pos", "ref", "alt", "ref_count", "alt_count"]
         ].rename(
             columns={
                 "ref_count": "expected_ref_count",
@@ -708,15 +849,6 @@ def _format_donor_results(
             }
         )
         annotations["region"] = annotations["chrom"] + "_" + annotations["pos"].astype(str)
-        annotations["snv_id"] = (
-            annotations["chrom"]
-            + ":"
-            + annotations["pos"].astype(str)
-            + ":"
-            + annotations["ref"]
-            + ":"
-            + annotations["alt"]
-        )
         results = annotations.merge(results, on="region", how="inner", validate="one_to_one")
         if len(results) != len(annotations):
             raise RuntimeError(f"Rust omitted eligible SNV results for donor {donor_id}")
@@ -933,6 +1065,7 @@ def run_per_donor_analysis(
 
         result_frames: list[pd.DataFrame] = []
         dispersion_rows: list[dict[str, Any]] = []
+        provenance_fits: dict[str, dict[str, Any]] = {}
         for donor_id in included_donors:
             donor_id = str(donor_id)
             donor_rows = eligible_rows.loc[eligible_rows["donor_id"] == donor_id].copy()
@@ -973,20 +1106,59 @@ def run_per_donor_analysis(
                 region_col=normalized_region_col,
             )
             result_frames.append(donor_results)
-            dispersion_rows.append(
+            dispersion_row = {
+                "donor_id": donor_id,
+                "dispersion_scope": dispersion_scope,
+                "fit_id": fit.fit_id,
+                "model": model,
+                "rho": fit.rho,
+                "linear_d1": fit.linear_d1,
+                "linear_d2": fit.linear_d2,
+            }
+            if fit.extended_contract:
+                dispersion_row.update(
+                    {
+                        "linear_depth_center": fit.linear_depth_center,
+                        "linear_depth_scale": fit.linear_depth_scale,
+                    }
+                )
+            dispersion_row.update(fit.metadata)
+            dispersion_row.update(
                 {
-                    "donor_id": donor_id,
-                    "dispersion_scope": dispersion_scope,
-                    "fit_id": fit.fit_id,
-                    "model": model,
-                    "rho": fit.rho,
-                    "linear_d1": fit.linear_d1,
-                    "linear_d2": fit.linear_d2,
                     "fit_observations": fit.n_observations,
                     "donor_eligible_snv_observations": len(donor_fit_rows),
                     "result_rows": len(donor_results),
                 }
             )
+            dispersion_rows.append(dispersion_row)
+
+            if fit.extended_contract or fit.metadata:
+                fit_record = {
+                    "fit_id": fit.fit_id,
+                    "model": model,
+                    "rho": fit.rho,
+                    "linear_d1": fit.linear_d1,
+                    "linear_d2": fit.linear_d2,
+                }
+                if fit.extended_contract:
+                    fit_record.update(
+                        {
+                            "linear_depth_center": fit.linear_depth_center,
+                            "linear_depth_scale": fit.linear_depth_scale,
+                        }
+                    )
+                fit_record.update(fit.metadata)
+                fit_record["fit_observations"] = fit.n_observations
+                existing_fit = provenance_fits.get(fit.fit_id)
+                if existing_fit is None:
+                    provenance_fits[fit.fit_id] = {**fit_record, "donor_ids": [donor_id]}
+                else:
+                    comparable = {
+                        key: value for key, value in existing_fit.items() if key != "donor_ids"
+                    }
+                    if comparable != fit_record:
+                        raise RuntimeError(f"Fit ID {fit.fit_id} mapped to inconsistent metadata")
+                    existing_fit["donor_ids"].append(donor_id)
 
         _require_unchanged(count_input)
         sort_columns = (
@@ -1049,6 +1221,8 @@ def run_per_donor_analysis(
             },
             "outputs": output_records,
         }
+        if provenance_fits:
+            provenance["dispersion_fits"] = list(provenance_fits.values())
         staged_paths["provenance"].write_text(
             json.dumps(provenance, indent=2, sort_keys=True) + "\n"
         )

--- a/src/counting/count_alleles.py
+++ b/src/counting/count_alleles.py
@@ -92,6 +92,19 @@ def make_count_df(bam_file: str, df: pl.DataFrame, use_rust: bool = True) -> pl.
 
     chrom_list = df.get_column("chrom").unique(maintain_order=True)
 
+    multi_allelic = (
+        df.select(["chrom", "pos", "ref", "alt"])
+        .unique()
+        .group_by(["chrom", "pos"])
+        .len()
+        .filter(pl.col("len") > 1)
+    )
+    if multi_allelic.height:
+        raise ValueError(
+            "Bulk allele counting supports biallelic positions only; "
+            "remove multi-allelic sites before counting"
+        )
+
     # Require Rust path (no Python fallback)
     if not (use_rust and RUST_AVAILABLE):
         raise RuntimeError(
@@ -117,9 +130,7 @@ def make_count_df(bam_file: str, df: pl.DataFrame, use_rust: bool = True) -> pl.
             chrom_df = df.filter(pl.col("chrom") == chrom)
 
             snp_list = (
-                chrom_df.select(["pos", "ref", "alt"])
-                .unique(subset=["pos"], maintain_order=True)
-                .iter_rows()
+                chrom_df.select(["pos", "ref", "alt"]).unique(maintain_order=True).iter_rows()
             )
 
             start = timeit.default_timer()

--- a/src/wasp2_rust/__init__.pyi
+++ b/src/wasp2_rust/__init__.pyi
@@ -45,13 +45,26 @@ class ImbalanceResult(TypedDict):
     pval: float
     fdr_pval: float
 
-class DispersionFit(TypedDict):
+class _DispersionFitDiagnostics(TypedDict, total=False):
+    """Optional optimizer diagnostics supplied by the Rust backend."""
+
+    fit_status: str
+    optimizer: str
+    optimizer_status: str | int
+    optimizer_converged: bool
+    optimizer_iterations: int
+    optimizer_evaluations: int
+    optimizer_objective: float
+
+class DispersionFit(_DispersionFitDiagnostics):
     """Dispersion parameters fitted from independent observations."""
 
     method: str
     rho: float | None
     linear_d1: float | None
     linear_d2: float | None
+    linear_depth_center: float | None
+    linear_depth_scale: float | None
     n_observations: int
 
 class ImbalanceRun(TypedDict):
@@ -62,6 +75,8 @@ class ImbalanceRun(TypedDict):
     rho: float | None
     linear_d1: float | None
     linear_d2: float | None
+    linear_depth_center: float | None
+    linear_depth_scale: float | None
     n_observations: int
     requested_phased: bool
     effective_phased: bool
@@ -620,6 +635,8 @@ def analyze_imbalance_run(
     rho: float | None = None,
     linear_d1: float | None = None,
     linear_d2: float | None = None,
+    linear_depth_center: float | None = None,
+    linear_depth_scale: float | None = None,
     exact_snv: bool | None = None,
 ) -> ImbalanceRun:
     """Analyze one table with optional fixed nuisance parameters."""

--- a/src/wasp2_rust/__init__.pyi
+++ b/src/wasp2_rust/__init__.pyi
@@ -4,6 +4,8 @@ This module provides high-performance implementations of bottleneck functions
 for allele-specific analysis in WASP2.
 """
 
+__version__: str
+
 from typing import TypedDict
 
 class UnifiedStats(TypedDict):
@@ -42,6 +44,30 @@ class ImbalanceResult(TypedDict):
     lrt: float
     pval: float
     fdr_pval: float
+
+class DispersionFit(TypedDict):
+    """Dispersion parameters fitted from independent observations."""
+
+    method: str
+    rho: float | None
+    linear_d1: float | None
+    linear_d2: float | None
+    n_observations: int
+
+class ImbalanceRun(TypedDict):
+    """One independent analysis run with fitted or fixed nuisance parameters."""
+
+    results: list[ImbalanceResult]
+    method: str
+    rho: float | None
+    linear_d1: float | None
+    linear_d2: float | None
+    n_observations: int
+    requested_phased: bool
+    effective_phased: bool
+    nuisance_source: str
+    exact_snv: bool
+    pvalue_method: str
 
 class VariantSpan(TypedDict):
     """Variant span information from intersection parsing."""
@@ -561,6 +587,8 @@ def analyze_imbalance(
     min_count: int = 10,
     pseudocount: int = 1,
     method: str = "single",
+    phased: bool = False,
+    region_col: str | None = None,
 ) -> list[ImbalanceResult]:
     """Analyze allelic imbalance using beta-binomial model.
 
@@ -580,4 +608,30 @@ def analyze_imbalance(
     list[ImbalanceResult]
         List of imbalance results per region.
     """
+    ...
+
+def analyze_imbalance_run(
+    tsv_path: str,
+    min_count: int = 10,
+    pseudocount: int = 1,
+    phased: bool = False,
+    region_col: str | None = None,
+    method: str = "single",
+    rho: float | None = None,
+    linear_d1: float | None = None,
+    linear_d2: float | None = None,
+    exact_snv: bool | None = None,
+) -> ImbalanceRun:
+    """Analyze one table with optional fixed nuisance parameters."""
+    ...
+
+def fit_imbalance_dispersion(
+    tsv_path: str,
+    min_count: int = 10,
+    pseudocount: int = 1,
+    method: str = "single",
+    phased: bool = False,
+    region_col: str | None = None,
+) -> DispersionFit:
+    """Fit reusable nuisance parameters from independent SNV observations."""
     ...

--- a/tests/analysis/test_donor_local_contract.py
+++ b/tests/analysis/test_donor_local_contract.py
@@ -1,0 +1,684 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+from collections.abc import Callable
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+from scipy.stats import false_discovery_control
+from typer.testing import CliRunner
+
+from analysis import __main__ as analysis_cli
+from analysis import run_analysis
+from analysis import run_analysis_per_donor as donor_analysis
+
+
+def _count_frame(*, overlap: bool = False, exact_duplicate: bool = False) -> pd.DataFrame:
+    rows: list[dict[str, Any]] = []
+    donor_counts = {
+        "donor_a": [(18, 2), (10, 10), (14, 6), (7, 13)],
+        "donor_b": [(16, 4), (9, 11), (13, 7), (8, 12)],
+    }
+    for donor_id, counts in donor_counts.items():
+        for index, (ref_count, alt_count) in enumerate(counts, start=1):
+            rows.append(
+                {
+                    "donor_id": donor_id,
+                    "chrom": "chr1",
+                    "pos": index * 100,
+                    "ref": "A",
+                    "alt": "G",
+                    "GT": "0|1" if index % 2 else "1|0",
+                    "region": f"feature_{(index + 1) // 2}",
+                    "ref_count": ref_count,
+                    "alt_count": alt_count,
+                }
+            )
+    if overlap:
+        for donor_id in donor_counts:
+            repeated = next(row.copy() for row in rows if row["donor_id"] == donor_id)
+            repeated["region"] = "feature_overlap"
+            rows.append(repeated)
+    if exact_duplicate:
+        rows.append(rows[0].copy())
+    return pd.DataFrame(rows)
+
+
+def _write_counts(
+    path: Path,
+    *,
+    donor_column: str = "donor_id",
+    overlap: bool = False,
+    exact_duplicate: bool = False,
+) -> pd.DataFrame:
+    frame = _count_frame(overlap=overlap, exact_duplicate=exact_duplicate)
+    if donor_column != "donor_id":
+        frame = frame.rename(columns={"donor_id": donor_column})
+    frame.to_csv(path, sep="\t", index=False)
+    return frame
+
+
+def _default_pvalues(frame: pd.DataFrame, groups: list[tuple[str, pd.DataFrame]]) -> list[float]:
+    del frame
+    return [min(0.95, 0.01 * (index + 1)) for index in range(len(groups))]
+
+
+def _install_backend(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    pvalues: Callable[[pd.DataFrame, list[tuple[str, pd.DataFrame]]], list[float]] = (
+        _default_pvalues
+    ),
+    scalar_rho: float = float.fromhex("0x1.23456789abcdep-5"),
+    linear_d1: float = float.fromhex("-0x1.3456789abcdep+1"),
+    linear_d2: float = float.fromhex("-0x1.23456789abcdep-6"),
+) -> dict[str, list[dict[str, Any]]]:
+    calls: dict[str, list[dict[str, Any]]] = {"fit": [], "analyze": []}
+
+    def fake_fit(path: str, *, min_count: int, pseudocount: int, method: str):
+        frame = pd.read_csv(path, sep="\t")
+        donors = tuple(frame["donor_id"].drop_duplicates())
+        fit_id = f"{method}:{','.join(donors)}"
+        payload = {
+            "fit_id": fit_id,
+            "method": method,
+            "rho": scalar_rho if method == "single" else None,
+            "linear_d1": linear_d1 if method == "linear" else None,
+            "linear_d2": linear_d2 if method == "linear" else None,
+            "n_observations": len(frame),
+        }
+        calls["fit"].append(
+            {
+                "frame": frame.copy(),
+                "min_count": min_count,
+                "pseudocount": pseudocount,
+                "method": method,
+                "payload": payload,
+            }
+        )
+        return payload
+
+    def fake_analyze(
+        path: str,
+        *,
+        min_count: int,
+        pseudocount: int,
+        phased: bool,
+        region_col: str | None,
+        method: str,
+        dispersion_fit: dict[str, Any],
+    ):
+        frame = pd.read_csv(path, sep="\t")
+        if region_col is None:
+            groups = [
+                (f"{row.chrom}_{row.pos}", frame.iloc[[index]])
+                for index, row in enumerate(frame.itertuples(index=False))
+            ]
+        else:
+            groups = [
+                (str(region), group.copy())
+                for region, group in frame.groupby(region_col, sort=False)
+            ]
+        raw_pvalues = pvalues(frame, groups)
+        adjusted = false_discovery_control(raw_pvalues, method="bh")
+        results = []
+        for (region, group), pval, fdr_pval in zip(groups, raw_pvalues, adjusted):
+            ref_count = int(group["ref_count"].sum())
+            alt_count = int(group["alt_count"].sum())
+            results.append(
+                {
+                    "region": region,
+                    "ref_count": ref_count,
+                    "alt_count": alt_count,
+                    "N": ref_count + alt_count,
+                    "snp_count": len(group),
+                    "null_ll": -3.0,
+                    "alt_ll": -2.0,
+                    "mu": 0.6,
+                    "lrt": 2.0,
+                    "pval": float(pval),
+                    "fdr_pval": float(fdr_pval),
+                }
+            )
+        calls["analyze"].append(
+            {
+                "frame": frame.copy(),
+                "min_count": min_count,
+                "pseudocount": pseudocount,
+                "phased": phased,
+                "region_col": region_col,
+                "method": method,
+                "dispersion_fit": dispersion_fit,
+            }
+        )
+        return {
+            "results": results,
+            "n_observations": len(frame),
+            "requested_phased": phased,
+            "effective_phased": phased,
+            "dispersion_fit": dispersion_fit,
+        }
+
+    monkeypatch.setattr(donor_analysis, "rust_fit_imbalance_dispersion", fake_fit)
+    monkeypatch.setattr(donor_analysis, "rust_analyze_imbalance_run", fake_analyze)
+    return calls
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("unit,region_col", [("snv", None), ("feature", "region")])
+@pytest.mark.parametrize("dispersion_scope", ["global", "per-donor"])
+@pytest.mark.parametrize("model", ["single", "linear"])
+def test_model_scope_unit_matrix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    unit: str,
+    region_col: str | None,
+    dispersion_scope: str,
+    model: str,
+) -> None:
+    counts = tmp_path / "counts.tsv"
+    _write_counts(counts)
+    calls = _install_backend(monkeypatch)
+
+    paths = donor_analysis.run_per_donor_analysis(
+        counts,
+        tmp_path / "results.tsv",
+        unit=unit,
+        model=model,
+        dispersion_scope=dispersion_scope,
+        region_col=region_col,
+        phased=False,
+        min_count=0,
+        pseudocount=0,
+        min_donor_observations=1,
+    )
+
+    assert len(calls["fit"]) == (1 if dispersion_scope == "global" else 2)
+    assert len(calls["analyze"]) == 2
+    assert {call["method"] for call in calls["fit"]} == {model}
+    assert {call["method"] for call in calls["analyze"]} == {model}
+    assert {call["region_col"] for call in calls["analyze"]} == {region_col}
+    assert all("donor_id" not in call["frame"] for call in calls["analyze"])
+    assert all(call["pseudocount"] == 0 for call in calls["fit"] + calls["analyze"])
+
+    fit_ids = [call["dispersion_fit"]["fit_id"] for call in calls["analyze"]]
+    assert (len(set(fit_ids)) == 1) is (dispersion_scope == "global")
+    results = pd.read_csv(paths["results"], sep="\t")
+    identity = "snv_id" if unit == "snv" else "feature_id"
+    assert results.groupby("donor_id")[identity].count().to_dict() == {
+        "donor_a": 4 if unit == "snv" else 2,
+        "donor_b": 4 if unit == "snv" else 2,
+    }
+    dispersion = pd.read_csv(paths["dispersion"], sep="\t")
+    assert dispersion["model"].eq(model).all()
+    assert dispersion["dispersion_scope"].eq(dispersion_scope).all()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("model", ["single", "linear"])
+def test_global_fit_payload_is_reused_exactly(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    model: str,
+) -> None:
+    counts = tmp_path / "counts.tsv"
+    _write_counts(counts)
+    calls = _install_backend(monkeypatch)
+
+    donor_analysis.run_per_donor_analysis(
+        counts,
+        tmp_path / "results.tsv",
+        unit="snv",
+        model=model,
+        dispersion_scope="global",
+        min_count=0,
+        pseudocount=0,
+        min_donor_observations=1,
+    )
+
+    fitted = calls["fit"][0]["payload"]
+    reused = [call["dispersion_fit"] for call in calls["analyze"]]
+    assert reused[0] is reused[1]
+    assert reused[0] == fitted
+    assert reused[0]["fit_id"] == fitted["fit_id"]
+    parameter_names = ["rho"] if model == "single" else ["linear_d1", "linear_d2"]
+    for parameter in parameter_names:
+        assert float(reused[0][parameter]).hex() == float(fitted[parameter]).hex()
+        assert float(reused[1][parameter]).hex() == float(fitted[parameter]).hex()
+
+
+@pytest.mark.unit
+def test_bh_correction_and_likelihood_calls_are_donor_local(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    counts = tmp_path / "counts.tsv"
+    _write_counts(counts)
+    expected = {
+        "donor_a": np.array([0.001, 0.04, 0.2, 0.8]),
+        "donor_b": np.array([0.03, 0.031, 0.032, 0.9]),
+    }
+
+    def donor_pvalues(frame: pd.DataFrame, groups: list[tuple[str, pd.DataFrame]]) -> list[float]:
+        donor_id = "donor_a" if int(frame.iloc[0]["ref_count"]) == 18 else "donor_b"
+        assert len(groups) == len(expected[donor_id])
+        return expected[donor_id].tolist()
+
+    calls = _install_backend(monkeypatch, pvalues=donor_pvalues)
+    paths = donor_analysis.run_per_donor_analysis(
+        counts,
+        tmp_path / "results.tsv",
+        unit="snv",
+        model="single",
+        dispersion_scope="per-donor",
+        min_count=0,
+        pseudocount=0,
+        min_donor_observations=1,
+    )
+
+    assert len(calls["analyze"]) == 2
+    assert all(len(call["frame"]) == 4 for call in calls["analyze"])
+    results = pd.read_csv(paths["results"], sep="\t")
+    observed_qvalues = []
+    for donor_id, raw_pvalues in expected.items():
+        donor_results = results.loc[results["donor_id"] == donor_id].sort_values("snv_id")
+        np.testing.assert_allclose(donor_results["pval"], raw_pvalues, rtol=0, atol=0)
+        expected_qvalues = false_discovery_control(raw_pvalues, method="bh")
+        np.testing.assert_allclose(donor_results["fdr_pval"], expected_qvalues, rtol=0, atol=1e-15)
+        observed_qvalues.extend(donor_results["fdr_pval"].tolist())
+    pooled_qvalues = false_discovery_control(np.concatenate(list(expected.values())), method="bh")
+    assert not np.allclose(observed_qvalues, pooled_qvalues)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("donor_column", ["donor_id", "sample"])
+def test_canonical_and_legacy_donor_columns_normalize_to_donor_id(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    donor_column: str,
+) -> None:
+    counts = tmp_path / "counts.tsv"
+    _write_counts(counts, donor_column=donor_column)
+    _install_backend(monkeypatch)
+
+    paths = donor_analysis.run_per_donor_analysis(
+        counts,
+        tmp_path / "results.tsv",
+        unit="snv",
+        min_count=0,
+        pseudocount=0,
+        min_donor_observations=1,
+    )
+
+    results = pd.read_csv(paths["results"], sep="\t")
+    assert "donor_id" in results
+    assert "sample" not in results
+    assert sorted(results["donor_id"].unique()) == ["donor_a", "donor_b"]
+    provenance = json.loads(paths["provenance"].read_text())
+    assert provenance["inputs"]["qc"]["legacy_sample_normalized"] is (donor_column == "sample")
+
+
+@pytest.mark.unit
+def test_both_donor_columns_fail_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    counts = tmp_path / "counts.tsv"
+    frame = _write_counts(counts)
+    frame["sample"] = frame["donor_id"]
+    frame.to_csv(counts, sep="\t", index=False)
+    _install_backend(monkeypatch)
+
+    with pytest.raises(ValueError, match="both donor_id and legacy sample"):
+        donor_analysis.run_per_donor_analysis(
+            counts,
+            tmp_path / "results.tsv",
+            unit="snv",
+            min_donor_observations=1,
+        )
+
+
+@pytest.mark.unit
+def test_overlapping_feature_membership_is_preserved_but_fit_once_per_snv(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    counts = tmp_path / "counts.tsv"
+    _write_counts(counts, overlap=True, exact_duplicate=True)
+    calls = _install_backend(monkeypatch)
+
+    paths = donor_analysis.run_per_donor_analysis(
+        counts,
+        tmp_path / "results.tsv",
+        unit="feature",
+        model="single",
+        dispersion_scope="global",
+        region_col="region",
+        min_count=0,
+        pseudocount=0,
+        min_donor_observations=1,
+    )
+
+    assert len(calls["fit"]) == 1
+    assert len(calls["fit"][0]["frame"]) == 8
+    assert [len(call["frame"]) for call in calls["analyze"]] == [5, 5]
+    results = pd.read_csv(paths["results"], sep="\t")
+    assert results.groupby("donor_id")["feature_id"].apply(set).to_dict() == {
+        "donor_a": {"feature_1", "feature_2", "feature_overlap"},
+        "donor_b": {"feature_1", "feature_2", "feature_overlap"},
+    }
+    provenance = json.loads(paths["provenance"].read_text())
+    input_qc = provenance["inputs"]["qc"]
+    assert input_qc["raw_rows"] == 11
+    assert input_qc["validated_rows"] == 10
+    assert input_qc["exact_duplicate_rows_removed"] == 1
+    assert input_qc["unique_donor_snv_rows"] == 8
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("conflict_column,replacement", [("alt", "T"), ("ref_count", 17)])
+def test_conflicting_repeated_feature_rows_fail_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    conflict_column: str,
+    replacement: Any,
+) -> None:
+    counts = tmp_path / "counts.tsv"
+    frame = _count_frame(overlap=True)
+    overlap_index = frame.index[
+        (frame["donor_id"] == "donor_a") & (frame["region"] == "feature_overlap")
+    ][0]
+    frame.loc[overlap_index, conflict_column] = replacement
+    frame.to_csv(counts, sep="\t", index=False)
+    calls = _install_backend(monkeypatch)
+
+    with pytest.raises(ValueError, match="Conflicting"):
+        donor_analysis.run_per_donor_analysis(
+            counts,
+            tmp_path / "results.tsv",
+            unit="feature",
+            region_col="region",
+            min_count=0,
+            min_donor_observations=1,
+        )
+    assert calls == {"fit": [], "analyze": []}
+
+
+@pytest.mark.unit
+def test_phased_snv_rejected_before_input_io(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _install_backend(monkeypatch)
+    with pytest.raises(ValueError, match="SNV analysis is unphased"):
+        donor_analysis.run_per_donor_analysis(
+            "does-not-exist.tsv",
+            "results.tsv",
+            unit="snv",
+            phased=True,
+        )
+    assert calls == {"fit": [], "analyze": []}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("bad_model", ["per_donor", "per-donor", "single-global", "mystery"])
+def test_unknown_and_legacy_pooled_models_fail_before_input_io(
+    monkeypatch: pytest.MonkeyPatch,
+    bad_model: str,
+) -> None:
+    calls = _install_backend(monkeypatch)
+    with pytest.raises(ValueError, match="single.*linear"):
+        donor_analysis.run_per_donor_analysis(
+            "does-not-exist.tsv",
+            "results.tsv",
+            unit="snv",
+            model=bad_model,
+        )
+    assert calls == {"fit": [], "analyze": []}
+
+
+@pytest.mark.unit
+def test_per_donor_route_defaults_to_raw_counts_without_pseudocount(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: dict[str, Any] = {}
+
+    def fake_run(count_file: str | Path, out_file: str | Path, **kwargs: Any):
+        observed.update({"count_file": count_file, "out_file": out_file, **kwargs})
+        return {"results": Path(out_file)}
+
+    monkeypatch.setattr(run_analysis, "run_per_donor_analysis", fake_run)
+    run_analysis.run_ai_analysis(
+        "counts.tsv",
+        out_file="results.tsv",
+        scope="per-donor",
+        unit="feature",
+        region_col="region",
+        model="linear",
+        dispersion_scope="global",
+    )
+
+    assert observed["unit"] == "feature"
+    assert observed["model"] == "linear"
+    assert observed["dispersion_scope"] == "global"
+    assert observed["pseudocount"] == 0
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("unit,region_col", [("snv", None), ("feature", "region")])
+@pytest.mark.parametrize("dispersion_scope", ["global", "per-donor"])
+@pytest.mark.parametrize("model", ["single", "linear"])
+def test_run_ai_analysis_forwards_model_scope_unit_matrix(
+    monkeypatch: pytest.MonkeyPatch,
+    unit: str,
+    region_col: str | None,
+    dispersion_scope: str,
+    model: str,
+) -> None:
+    observed: dict[str, Any] = {}
+
+    def fake_run(count_file: str | Path, out_file: str | Path, **kwargs: Any):
+        observed.update({"count_file": count_file, "out_file": out_file, **kwargs})
+        return {"results": Path(out_file)}
+
+    monkeypatch.setattr(run_analysis, "run_per_donor_analysis", fake_run)
+    run_analysis.run_ai_analysis(
+        "counts.tsv",
+        out_file="results.tsv",
+        scope="per-donor",
+        unit=unit,
+        region_col=region_col,
+        model=model,
+        dispersion_scope=dispersion_scope,
+    )
+
+    assert observed["unit"] == unit
+    assert observed["region_col"] == region_col
+    assert observed["model"] == model
+    assert observed["dispersion_scope"] == dispersion_scope
+    assert observed["pseudocount"] == 0
+
+
+@pytest.mark.unit
+def test_console_interface_forwards_donor_local_options(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: dict[str, Any] = {}
+
+    def fake_run(**kwargs: Any) -> None:
+        observed.update(kwargs)
+
+    monkeypatch.setattr(analysis_cli, "run_ai_analysis", fake_run)
+    manifest_digest = "a" * 64
+    result = CliRunner().invoke(
+        analysis_cli.app,
+        [
+            "find-imbalance",
+            "count-bundle",
+            "--scope",
+            "per-donor",
+            "--unit",
+            "feature",
+            "--model",
+            "linear",
+            "--dispersion-scope",
+            "global",
+            "--region-col",
+            "region",
+            "--pseudocount",
+            "0",
+            "--min-donor-observations",
+            "12",
+            "--expected-manifest-sha256",
+            manifest_digest,
+            "-o",
+            "results.tsv",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert observed["count_file"] == "count-bundle"
+    assert observed["out_file"] == "results.tsv"
+    assert observed["scope"] == "per-donor"
+    assert observed["unit"] == "feature"
+    assert observed["model"] == "linear"
+    assert observed["dispersion_scope"] == "global"
+    assert observed["pseudocount"] == 0
+    assert observed["min_donor_observations"] == 12
+    assert observed["expected_manifest_sha256"] == manifest_digest
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("bad_model", ["per_donor", "per-donor", "single-global", "mystery"])
+def test_legacy_global_route_rejects_unknown_models(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    bad_model: str,
+) -> None:
+    counts = tmp_path / "counts.tsv"
+    _write_counts(counts)
+    monkeypatch.setattr(run_analysis, "rust_analyze_imbalance", lambda *args, **kwargs: [])
+
+    with pytest.raises(ValueError, match="single.*linear"):
+        run_analysis.run_ai_analysis(
+            counts,
+            out_file=tmp_path / "results.tsv",
+            model=bad_model,
+            per_variant=True,
+        )
+
+
+@pytest.mark.unit
+def test_retired_cohort_shared_surface_is_absent() -> None:
+    assert importlib.util.find_spec("analysis.run_analysis_cohort_shared") is None
+    assert not hasattr(run_analysis, "run_cohort_shared_snv_analysis")
+    with pytest.raises(ValueError, match="scope must be 'per-donor'"):
+        run_analysis.run_ai_analysis(
+            "does-not-exist.tsv",
+            scope="cohort-shared",
+            unit="snv",
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("unit,region_col", [("snv", None), ("feature", "region")])
+def test_sidecar_and_provenance_schema(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    unit: str,
+    region_col: str | None,
+) -> None:
+    counts = tmp_path / "counts.tsv"
+    _write_counts(counts)
+    _install_backend(monkeypatch)
+    paths = donor_analysis.run_per_donor_analysis(
+        counts,
+        tmp_path / "results.tsv",
+        unit=unit,
+        model="linear",
+        dispersion_scope="global",
+        region_col=region_col,
+        min_count=0,
+        pseudocount=0,
+        min_donor_observations=1,
+    )
+
+    assert set(paths) == {"results", "dispersion", "qc", "provenance"}
+    assert all(path.is_file() for path in paths.values())
+    result_prefix = (
+        ["donor_id", "snv_id", "chrom", "pos", "ref", "alt"]
+        if unit == "snv"
+        else ["donor_id", "feature_id"]
+    )
+    assert pd.read_csv(paths["results"], sep="\t").columns.tolist() == [
+        *result_prefix,
+        "ref_count",
+        "alt_count",
+        "N",
+        "snp_count",
+        "null_ll",
+        "alt_ll",
+        "mu",
+        "lrt",
+        "pval",
+        "fdr_pval",
+        "significant_q05",
+        "significant_q10",
+    ]
+    assert pd.read_csv(paths["dispersion"], sep="\t").columns.tolist() == [
+        "donor_id",
+        "dispersion_scope",
+        "fit_id",
+        "model",
+        "rho",
+        "linear_d1",
+        "linear_d2",
+        "fit_observations",
+        "donor_eligible_snv_observations",
+        "result_rows",
+    ]
+    assert pd.read_csv(paths["qc"], sep="\t").columns.tolist() == [
+        "donor_id",
+        "input_rows",
+        "unique_snv_rows",
+        "eligible_snv_observations",
+        "eligible_test_rows",
+        "analyzed",
+        "status",
+    ]
+
+    provenance = json.loads(paths["provenance"].read_text())
+    assert set(provenance) == {
+        "schema_version",
+        "created_at_utc",
+        "software",
+        "analysis",
+        "parameters",
+        "inputs",
+        "donors",
+        "outputs",
+    }
+    assert provenance["schema_version"] == donor_analysis.SCHEMA_VERSION
+    datetime.fromisoformat(provenance["created_at_utc"])
+    assert provenance["analysis"] == {
+        "scope": "per-donor",
+        "unit": unit,
+        "model": "linear",
+        "dispersion_scope": "global",
+        "region_col": region_col,
+        "phased": False,
+        "multiple_testing": "Benjamini-Hochberg independently within each donor",
+    }
+    assert provenance["parameters"] == {
+        "min_count": 0,
+        "pseudocount": 0,
+        "min_donor_observations": 1,
+    }
+    assert provenance["donors"] == {"total": 2, "included": 2, "excluded": 0}
+    assert set(provenance["outputs"]) == {"results", "dispersion", "qc"}
+    for name, record in provenance["outputs"].items():
+        assert set(record) == {"path", "sha256", "size_bytes", "mtime_utc"}
+        assert record["path"] == paths[name].name
+        assert record["sha256"] == hashlib.sha256(paths[name].read_bytes()).hexdigest()
+        assert record["size_bytes"] == paths[name].stat().st_size
+        datetime.fromisoformat(record["mtime_utc"])

--- a/tests/analysis/test_donor_local_statistics.py
+++ b/tests/analysis/test_donor_local_statistics.py
@@ -62,8 +62,15 @@ def _rho_at_depth(dispersion: pd.Series, total: int) -> float:
     if dispersion["model"] == "single":
         rho = float(dispersion["rho"])
     else:
-        linear = float(dispersion["linear_d1"]) + total * float(dispersion["linear_d2"])
-        rho = float(expit(np.clip(linear, -10.0, 10.0)))
+        center = float(dispersion["linear_depth_center"])
+        scale = float(dispersion["linear_depth_scale"])
+        assert np.isfinite(center)
+        assert np.isfinite(scale) and scale > 0
+        standardized_depth = (total - center) / scale
+        linear = float(dispersion["linear_d1"]) + standardized_depth * float(
+            dispersion["linear_d2"]
+        )
+        rho = float(expit(linear))
     return float(np.clip(rho, RHO_EPSILON, 1.0 - RHO_EPSILON))
 
 
@@ -229,7 +236,16 @@ def test_model_scope_unit_matrix_matches_independent_scipy_oracle(
     assert observed["alt_count"].sum() == counts["alt_count"].sum()
     if dispersion_scope == "global":
         assert dispersion["fit_id"].nunique() == 1
-        parameters = ["rho"] if model == "single" else ["linear_d1", "linear_d2"]
+        parameters = (
+            ["rho"]
+            if model == "single"
+            else [
+                "linear_d1",
+                "linear_d2",
+                "linear_depth_center",
+                "linear_depth_scale",
+            ]
+        )
         assert all(dispersion[column].nunique() == 1 for column in parameters)
     else:
         assert dispersion["fit_id"].nunique() == 2

--- a/tests/analysis/test_donor_local_statistics.py
+++ b/tests/analysis/test_donor_local_statistics.py
@@ -1,0 +1,356 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+from scipy.optimize import minimize_scalar
+from scipy.special import expit, logsumexp
+from scipy.stats import betabinom, chi2, false_discovery_control
+
+from analysis import run_analysis_per_donor as donor_analysis
+
+RHO_EPSILON = 1e-10
+
+
+def _statistical_counts() -> pd.DataFrame:
+    rows: list[dict[str, Any]] = []
+    counts = {
+        "donor_a": [(18, 2), (22, 8), (32, 8), (14, 6), (24, 26), (11, 9)],
+        "donor_b": [(16, 4), (18, 12), (29, 11), (8, 12), (27, 23), (9, 11)],
+    }
+    for donor_id, donor_counts in counts.items():
+        for index, (ref_count, alt_count) in enumerate(donor_counts, start=1):
+            rows.append(
+                {
+                    "donor_id": donor_id,
+                    "chrom": "chr1",
+                    "pos": index * 100,
+                    "ref": "A",
+                    "alt": "G",
+                    "GT": "0|1" if index % 2 else "1|0",
+                    "region": f"feature_{(index + 1) // 2}",
+                    "ref_count": ref_count,
+                    "alt_count": alt_count,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+@pytest.fixture
+def rust_backend(monkeypatch: pytest.MonkeyPatch):
+    wasp2_rust = pytest.importorskip("wasp2_rust")
+    required = ["fit_imbalance_dispersion", "analyze_imbalance_run", "analyze_imbalance"]
+    if not all(hasattr(wasp2_rust, name) for name in required):
+        pytest.skip("worktree Rust extension needs rebuilding")
+    monkeypatch.setattr(
+        donor_analysis,
+        "rust_fit_imbalance_dispersion",
+        wasp2_rust.fit_imbalance_dispersion,
+    )
+    monkeypatch.setattr(
+        donor_analysis,
+        "rust_analyze_imbalance_run",
+        wasp2_rust.analyze_imbalance_run,
+    )
+    return wasp2_rust
+
+
+def _rho_at_depth(dispersion: pd.Series, total: int) -> float:
+    if dispersion["model"] == "single":
+        rho = float(dispersion["rho"])
+    else:
+        linear = float(dispersion["linear_d1"]) + total * float(dispersion["linear_d2"])
+        rho = float(expit(np.clip(linear, -10.0, 10.0)))
+    return float(np.clip(rho, RHO_EPSILON, 1.0 - RHO_EPSILON))
+
+
+def _logpmf(probability: float, rho: float, ref_count: int, total: int) -> float:
+    if probability <= 0.0 or probability >= 1.0:
+        return -np.inf
+    alpha = probability * (1.0 - rho) / rho
+    beta = (1.0 - probability) * (1.0 - rho) / rho
+    return float(betabinom.logpmf(ref_count, total, alpha, beta))
+
+
+def _exact_two_sided_pvalue(ref_count: int, total: int, rho: float) -> float:
+    outcomes = np.arange(total + 1)
+    alpha = 0.5 * (1.0 - rho) / rho
+    log_probabilities = betabinom.logpmf(outcomes, total, alpha, alpha)
+    observed_deviation = abs(2 * ref_count - total)
+    tail = np.abs(2 * outcomes - total) >= observed_deviation
+    return float(np.exp(logsumexp(log_probabilities[tail]) - logsumexp(log_probabilities)))
+
+
+def _single_snv_oracle(row: pd.Series, dispersion: pd.Series) -> dict[str, float]:
+    ref_count = int(row["ref_count"])
+    alt_count = int(row["alt_count"])
+    total = ref_count + alt_count
+    rho = _rho_at_depth(dispersion, total)
+    null_ll = _logpmf(0.5, rho, ref_count, total)
+    fit = minimize_scalar(
+        lambda probability: -_logpmf(probability, rho, ref_count, total),
+        bounds=(0.0, 1.0),
+        method="bounded",
+        options={"xatol": 1e-10},
+    )
+    assert fit.success
+    alt_ll = -float(fit.fun)
+    lrt = max(0.0, 2.0 * (alt_ll - null_ll))
+    return {
+        "null_ll": null_ll,
+        "alt_ll": alt_ll,
+        "mu": float(fit.x),
+        "lrt": lrt,
+        "pval": _exact_two_sided_pvalue(ref_count, total, rho),
+    }
+
+
+def _unphased_feature_oracle(frame: pd.DataFrame, dispersion: pd.Series) -> dict[str, float]:
+    observations = []
+    for row in frame.sort_values(["chrom", "pos", "ref_count", "alt_count"]).itertuples():
+        total = int(row.ref_count + row.alt_count)
+        observations.append((int(row.ref_count), total, _rho_at_depth(dispersion, total)))
+    null_ll = sum(_logpmf(0.5, rho, ref_count, total) for ref_count, total, rho in observations)
+
+    def negative_log_likelihood(probability: float) -> float:
+        log_likelihood = 0.0
+        for ref_count, total, rho in observations:
+            orientations = [
+                _logpmf(probability, rho, ref_count, total),
+                _logpmf(1.0 - probability, rho, ref_count, total),
+            ]
+            log_likelihood += float(logsumexp(orientations) - np.log(2.0))
+        return -log_likelihood
+
+    fit = minimize_scalar(
+        negative_log_likelihood,
+        bounds=(0.5, 1.0),
+        method="bounded",
+        options={"xatol": 1e-10},
+    )
+    assert fit.success
+    alt_ll = -float(fit.fun)
+    lrt = max(0.0, 2.0 * (alt_ll - null_ll))
+    return {
+        "null_ll": null_ll,
+        "alt_ll": alt_ll,
+        "mu": float(fit.x),
+        "lrt": lrt,
+        "pval": float(chi2.sf(lrt, 1)),
+    }
+
+
+def _oracle_results(
+    counts: pd.DataFrame,
+    dispersion: pd.DataFrame,
+    *,
+    unit: str,
+) -> pd.DataFrame:
+    rows = []
+    for donor_id, donor_counts in counts.groupby("donor_id", sort=True):
+        donor_dispersion = dispersion.loc[dispersion["donor_id"] == donor_id].iloc[0]
+        if unit == "snv":
+            for row in donor_counts.sort_values(["chrom", "pos"]).to_dict("records"):
+                series = pd.Series(row)
+                rows.append(
+                    {
+                        "donor_id": donor_id,
+                        "identity": (f"{row['chrom']}:{row['pos']}:{row['ref']}:{row['alt']}"),
+                        **_single_snv_oracle(series, donor_dispersion),
+                    }
+                )
+        else:
+            for feature_id, feature in donor_counts.groupby("region", sort=True):
+                rows.append(
+                    {
+                        "donor_id": donor_id,
+                        "identity": feature_id,
+                        **_unphased_feature_oracle(feature, donor_dispersion),
+                    }
+                )
+    oracle = pd.DataFrame(rows)
+    oracle["fdr_pval"] = oracle.groupby("donor_id", sort=False)["pval"].transform(
+        lambda values: false_discovery_control(values.to_numpy(), method="bh")
+    )
+    return oracle.sort_values(["donor_id", "identity"]).reset_index(drop=True)
+
+
+@pytest.mark.rust
+@pytest.mark.parametrize("unit,region_col", [("snv", None), ("feature", "region")])
+@pytest.mark.parametrize("dispersion_scope", ["global", "per-donor"])
+@pytest.mark.parametrize("model", ["single", "linear"])
+def test_model_scope_unit_matrix_matches_independent_scipy_oracle(
+    tmp_path: Path,
+    rust_backend: Any,
+    unit: str,
+    region_col: str | None,
+    dispersion_scope: str,
+    model: str,
+) -> None:
+    del rust_backend
+    counts = _statistical_counts()
+    count_path = tmp_path / "counts.tsv"
+    counts.to_csv(count_path, sep="\t", index=False)
+    paths = donor_analysis.run_per_donor_analysis(
+        count_path,
+        tmp_path / f"{unit}-{model}-{dispersion_scope}.tsv",
+        unit=unit,
+        model=model,
+        dispersion_scope=dispersion_scope,
+        region_col=region_col,
+        phased=False,
+        min_count=0,
+        pseudocount=0,
+        min_donor_observations=4,
+    )
+
+    observed = pd.read_csv(paths["results"], sep="\t")
+    identity_column = "snv_id" if unit == "snv" else "feature_id"
+    observed = observed.rename(columns={identity_column: "identity"}).sort_values(
+        ["donor_id", "identity"]
+    )
+    observed = observed.reset_index(drop=True)
+    dispersion = pd.read_csv(paths["dispersion"], sep="\t")
+    oracle = _oracle_results(counts, dispersion, unit=unit)
+
+    assert observed[["donor_id", "identity"]].equals(oracle[["donor_id", "identity"]])
+    for column in ["null_ll", "alt_ll", "mu", "lrt", "pval", "fdr_pval"]:
+        np.testing.assert_allclose(
+            observed[column],
+            oracle[column],
+            rtol=3e-5,
+            atol=3e-5,
+            err_msg=f"{model}/{dispersion_scope}/{unit}: {column}",
+        )
+    assert observed["ref_count"].sum() == counts["ref_count"].sum()
+    assert observed["alt_count"].sum() == counts["alt_count"].sum()
+    if dispersion_scope == "global":
+        assert dispersion["fit_id"].nunique() == 1
+        parameters = ["rho"] if model == "single" else ["linear_d1", "linear_d2"]
+        assert all(dispersion[column].nunique() == 1 for column in parameters)
+    else:
+        assert dispersion["fit_id"].nunique() == 2
+
+
+def _run_legacy(
+    rust_backend: Any,
+    path: Path,
+    *,
+    method: str,
+    phased: bool,
+    region_col: str | None,
+) -> pd.DataFrame:
+    results = rust_backend.analyze_imbalance(
+        str(path),
+        min_count=0,
+        pseudocount=0,
+        method=method,
+        phased=phased,
+        region_col=region_col,
+    )
+    return pd.DataFrame(results).sort_values("region").reset_index(drop=True)
+
+
+@pytest.mark.rust
+@pytest.mark.parametrize("method", ["single", "linear"])
+def test_unphased_feature_results_are_row_permutation_invariant(
+    tmp_path: Path,
+    rust_backend: Any,
+    method: str,
+) -> None:
+    counts = (
+        _statistical_counts()
+        .loc[lambda frame: frame["donor_id"] == "donor_a"]
+        .drop(columns="donor_id")
+    )
+    forward = tmp_path / "forward.tsv"
+    shuffled = tmp_path / "shuffled.tsv"
+    counts.to_csv(forward, sep="\t", index=False)
+    counts.sample(frac=1.0, random_state=1729).to_csv(shuffled, sep="\t", index=False)
+
+    first = _run_legacy(rust_backend, forward, method=method, phased=False, region_col="region")
+    second = _run_legacy(rust_backend, shuffled, method=method, phased=False, region_col="region")
+    assert first[["region", "ref_count", "alt_count", "N", "snp_count"]].equals(
+        second[["region", "ref_count", "alt_count", "N", "snp_count"]]
+    )
+    for column in ["null_ll", "alt_ll", "mu", "lrt", "pval", "fdr_pval"]:
+        np.testing.assert_allclose(first[column], second[column], rtol=0, atol=1e-12)
+
+
+@pytest.mark.rust
+@pytest.mark.parametrize("method", ["single", "linear"])
+def test_allele_swap_preserves_tests_and_mirrors_single_snp_mu(
+    tmp_path: Path,
+    rust_backend: Any,
+    method: str,
+) -> None:
+    counts = (
+        _statistical_counts()
+        .loc[lambda frame: frame["donor_id"] == "donor_a"]
+        .drop(columns=["donor_id", "region"])
+    )
+    original_path = tmp_path / "original.tsv"
+    swapped_path = tmp_path / "swapped.tsv"
+    counts.to_csv(original_path, sep="\t", index=False)
+    swapped = counts.copy()
+    swapped[["ref", "alt"]] = swapped[["alt", "ref"]].to_numpy()
+    swapped[["ref_count", "alt_count"]] = swapped[["alt_count", "ref_count"]].to_numpy()
+    swapped["GT"] = swapped["GT"].map({"0|1": "1|0", "1|0": "0|1"})
+    swapped.to_csv(swapped_path, sep="\t", index=False)
+
+    original = _run_legacy(
+        rust_backend, original_path, method=method, phased=False, region_col=None
+    )
+    swapped_results = _run_legacy(
+        rust_backend, swapped_path, method=method, phased=False, region_col=None
+    )
+    for column in ["null_ll", "alt_ll", "lrt", "pval", "fdr_pval"]:
+        np.testing.assert_allclose(original[column], swapped_results[column], rtol=0, atol=2e-10)
+    np.testing.assert_allclose(
+        original["mu"] + swapped_results["mu"], np.ones(len(original)), rtol=0, atol=2e-5
+    )
+
+
+@pytest.mark.rust
+@pytest.mark.parametrize("method", ["single", "linear"])
+def test_single_snp_results_are_phase_invariant(
+    tmp_path: Path,
+    rust_backend: Any,
+    method: str,
+) -> None:
+    counts = (
+        _statistical_counts()
+        .loc[lambda frame: frame["donor_id"] == "donor_a"]
+        .drop(columns=["donor_id", "region"])
+    )
+    path = tmp_path / "counts.tsv"
+    counts.to_csv(path, sep="\t", index=False)
+    unphased = _run_legacy(rust_backend, path, method=method, phased=False, region_col=None)
+    phased = _run_legacy(rust_backend, path, method=method, phased=True, region_col=None)
+
+    assert unphased[["region", "ref_count", "alt_count", "N", "snp_count"]].equals(
+        phased[["region", "ref_count", "alt_count", "N", "snp_count"]]
+    )
+    for column in ["null_ll", "alt_ll", "mu", "lrt", "pval", "fdr_pval"]:
+        np.testing.assert_allclose(unphased[column], phased[column], rtol=0, atol=1e-12)
+
+
+@pytest.mark.rust
+@pytest.mark.parametrize("method", ["per_donor", "per-donor", "single-global", "mystery"])
+def test_rust_rejects_unknown_and_retired_pooled_methods(
+    tmp_path: Path,
+    rust_backend: Any,
+    method: str,
+) -> None:
+    path = tmp_path / "counts.tsv"
+    _statistical_counts().drop(columns="donor_id").to_csv(path, sep="\t", index=False)
+    with pytest.raises(RuntimeError, match="removed|Unknown method"):
+        rust_backend.analyze_imbalance(str(path), method=method)
+
+
+@pytest.mark.rust
+def test_rust_has_no_cohort_shared_entry_point(rust_backend: Any) -> None:
+    assert not hasattr(rust_backend, "analyze_cohort_snvs")

--- a/tests/analysis/test_per_donor_peak.py
+++ b/tests/analysis/test_per_donor_peak.py
@@ -1,0 +1,140 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from analysis import run_analysis_per_donor as peak_analysis
+
+
+def _write_peak_counts(path: Path, *, bad_gt: bool = False) -> None:
+    rows = []
+    for donor in ["donor_a", "donor_b", "donor_low"]:
+        count = 50 if donor != "donor_low" else 2
+        for index in range(count):
+            ref, alt = ("A", "G")
+            gt = f"{ref}|{alt}" if index % 2 == 0 else f"{alt}|{ref}"
+            if bad_gt and donor == "donor_a" and index == 0:
+                gt = "A/G"
+            rows.append(
+                {
+                    "chrom": "chr1",
+                    "pos": index + 1,
+                    "ref": ref,
+                    "alt": alt,
+                    "GT": gt,
+                    "capeak_id": f"peak_{index // 2}",
+                    "ref_count": 8,
+                    "alt_count": 4,
+                    "sample": donor,
+                    "is_caqtl": index // 2 % 2 == 0,
+                }
+            )
+    pd.DataFrame(rows).to_csv(path, sep="\t", index=False)
+
+
+@pytest.mark.unit
+def test_per_donor_peak_analysis_normalizes_phase_and_isolates_models(tmp_path, monkeypatch):
+    counts = tmp_path / "counts.tsv"
+    _write_peak_counts(counts)
+    calls = []
+
+    def fake_fit(path, **kwargs):
+        frame = pd.read_csv(path, sep="\t")
+        donor = ",".join(frame["donor_id"].drop_duplicates())
+        return {
+            "fit_id": f"linear:{donor}",
+            "method": "linear",
+            "rho": None,
+            "linear_d1": -3.0,
+            "linear_d2": -0.04,
+            "n_observations": len(frame),
+        }
+
+    def fake_rust(path, *, dispersion_fit, **kwargs):
+        frame = pd.read_csv(path, sep="\t")
+        assert set(frame["GT"]) == {"0|1", "1|0"}
+        assert kwargs["region_col"] == "capeak_id"
+        assert kwargs["method"] == "linear"
+        calls.append((len(frame), kwargs["phased"]))
+        results = []
+        for region, group in frame.groupby("capeak_id", sort=True):
+            ref_count = int(group["ref_count"].sum())
+            alt_count = int(group["alt_count"].sum())
+            results.append(
+                {
+                    "region": region,
+                    "ref_count": ref_count,
+                    "alt_count": alt_count,
+                    "N": ref_count + alt_count,
+                    "snp_count": len(group),
+                    "null_ll": -3.0,
+                    "alt_ll": -2.0,
+                    "mu": 0.6,
+                    "lrt": 2.0,
+                    "pval": 0.02,
+                    "fdr_pval": 0.04,
+                }
+            )
+        return {
+            "results": results,
+            "n_observations": len(frame),
+            "requested_phased": True,
+            "effective_phased": True,
+            "dispersion_fit": dispersion_fit,
+        }
+
+    monkeypatch.setattr(peak_analysis, "rust_fit_imbalance_dispersion", fake_fit)
+    monkeypatch.setattr(peak_analysis, "rust_analyze_imbalance_run", fake_rust)
+    paths = peak_analysis.run_per_donor_analysis(
+        counts,
+        tmp_path / "peak_linear_phased.tsv",
+        unit="feature",
+        region_col="capeak_id",
+        model="linear",
+        phased=True,
+    )
+
+    assert calls == [(50, True), (50, True)]
+    results = pd.read_csv(paths["results"], sep="\t")
+    assert results.groupby("donor_id").size().to_dict() == {"donor_a": 25, "donor_b": 25}
+    assert results["significant_q05"].all()
+    dispersion = pd.read_csv(paths["dispersion"], sep="\t")
+    assert dispersion["rho"].isna().all()
+    assert dispersion["linear_d1"].eq(-3.0).all()
+    qc = pd.read_csv(paths["qc"], sep="\t").set_index("donor_id")
+    assert qc.loc["donor_low", "status"] == "excluded_min_observations"
+    provenance = json.loads(paths["provenance"].read_text())
+    assert provenance["analysis"]["scope"] == "per-donor"
+    assert provenance["analysis"]["phased"] is True
+
+
+@pytest.mark.unit
+def test_per_donor_peak_analysis_rejects_nonphased_gt(tmp_path, monkeypatch):
+    counts = tmp_path / "counts.tsv"
+    _write_peak_counts(counts, bad_gt=True)
+    monkeypatch.setattr(peak_analysis, "rust_fit_imbalance_dispersion", lambda *a, **k: None)
+    monkeypatch.setattr(peak_analysis, "rust_analyze_imbalance_run", lambda *a, **k: None)
+    with pytest.raises(ValueError, match="Phased GT must be exact"):
+        peak_analysis.run_per_donor_analysis(
+            counts,
+            tmp_path / "results.tsv",
+            unit="feature",
+            region_col="capeak_id",
+            phased=True,
+        )
+
+
+@pytest.mark.unit
+def test_per_donor_peak_analysis_requires_explicit_region(tmp_path, monkeypatch):
+    counts = tmp_path / "counts.tsv"
+    _write_peak_counts(counts)
+    monkeypatch.setattr(peak_analysis, "rust_fit_imbalance_dispersion", lambda *a, **k: None)
+    monkeypatch.setattr(peak_analysis, "rust_analyze_imbalance_run", lambda *a, **k: None)
+    with pytest.raises(ValueError, match="requires --region-col"):
+        peak_analysis.run_per_donor_analysis(
+            counts,
+            tmp_path / "results.tsv",
+            unit="feature",
+            region_col="",
+        )

--- a/tests/analysis/test_per_donor_snv.py
+++ b/tests/analysis/test_per_donor_snv.py
@@ -1,0 +1,140 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from analysis import run_analysis_per_donor as cohort_analysis
+from analysis.run_analysis import run_ai_analysis
+
+
+def _write_counts(path: Path) -> None:
+    rows = []
+    for sample, count in [("donor_a", 50), ("donor_b", 51), ("donor_low", 2)]:
+        for index in range(count):
+            rows.append(
+                {
+                    "chrom": "chr1",
+                    "pos": index + 1,
+                    "ref": "A",
+                    "alt": "G",
+                    "ref_count": 8,
+                    "alt_count": 4,
+                    "sample": sample,
+                    "snv_id": f"chr1:{index + 1}:A:G",
+                    "capeak_id": f"peak_{index // 2}",
+                    "is_caqtl": index % 2 == 0,
+                }
+            )
+    pd.DataFrame(rows).to_csv(path, sep="\t", index=False)
+
+
+@pytest.mark.unit
+def test_per_donor_analysis_isolates_rho_and_bh(tmp_path, monkeypatch):
+    counts = tmp_path / "counts.tsv"
+    _write_counts(counts)
+    calls = []
+
+    def fake_fit(path, **kwargs):
+        frame = pd.read_csv(path, sep="\t")
+        donor = ",".join(frame["donor_id"].drop_duplicates())
+        return {
+            "fit_id": f"single:{donor}",
+            "method": "single",
+            "rho": len(frame) / 1000,
+            "linear_d1": None,
+            "linear_d2": None,
+            "n_observations": len(frame),
+        }
+
+    def fake_rust(path, *, dispersion_fit, **kwargs):
+        frame = pd.read_csv(path, sep="\t")
+        assert "sample" not in frame.columns
+        assert "donor_id" not in frame.columns
+        calls.append(len(frame))
+        results = []
+        for row in frame.itertuples(index=False):
+            results.append(
+                {
+                    "region": f"{row.chrom}_{row.pos}",
+                    "ref_count": row.ref_count,
+                    "alt_count": row.alt_count,
+                    "N": row.ref_count + row.alt_count,
+                    "snp_count": 1,
+                    "null_ll": -2.0,
+                    "alt_ll": -1.0,
+                    "mu": 0.6,
+                    "lrt": 2.0,
+                    "pval": 0.02,
+                    "fdr_pval": 0.04,
+                }
+            )
+        return {
+            "results": results,
+            "n_observations": len(frame),
+            "requested_phased": False,
+            "effective_phased": False,
+            "dispersion_fit": dispersion_fit,
+        }
+
+    monkeypatch.setattr(cohort_analysis, "rust_fit_imbalance_dispersion", fake_fit)
+    monkeypatch.setattr(cohort_analysis, "rust_analyze_imbalance_run", fake_rust)
+    output = tmp_path / "results.tsv"
+    paths = cohort_analysis.run_per_donor_analysis(
+        counts,
+        output,
+        unit="snv",
+        min_donor_observations=50,
+    )
+
+    assert sorted(calls) == [50, 51]
+    results = pd.read_csv(paths["results"], sep="\t")
+    assert results.groupby("donor_id").size().to_dict() == {"donor_a": 50, "donor_b": 51}
+    assert results["significant_q05"].all()
+    qc = pd.read_csv(paths["qc"], sep="\t").set_index("donor_id")
+    assert qc.loc["donor_low", "status"] == "excluded_min_observations"
+    assert not bool(qc.loc["donor_low", "analyzed"])
+    dispersion = pd.read_csv(paths["dispersion"], sep="\t")
+    assert dispersion["donor_id"].tolist() == ["donor_a", "donor_b"]
+    provenance = json.loads(paths["provenance"].read_text())
+    assert provenance["analysis"]["scope"] == "per-donor"
+    assert provenance["analysis"]["multiple_testing"].endswith("within each donor")
+    assert provenance["donors"] == {"excluded": 1, "included": 2, "total": 3}
+
+
+@pytest.mark.unit
+def test_per_donor_analysis_rejects_conflicting_site_rows(tmp_path, monkeypatch):
+    counts = tmp_path / "counts.tsv"
+    pd.DataFrame(
+        [
+            ["chr1", 1, "A", "G", 8, 4, "donor_a"],
+            ["chr1", 1, "A", "T", 8, 4, "donor_a"],
+        ],
+        columns=["chrom", "pos", "ref", "alt", "ref_count", "alt_count", "sample"],
+    ).to_csv(counts, sep="\t", index=False)
+    monkeypatch.setattr(cohort_analysis, "rust_fit_imbalance_dispersion", lambda *a, **k: None)
+    monkeypatch.setattr(cohort_analysis, "rust_analyze_imbalance_run", lambda *a, **k: None)
+    with pytest.raises(ValueError, match="Conflicting alleles"):
+        cohort_analysis.run_per_donor_analysis(
+            counts,
+            tmp_path / "results.tsv",
+            unit="snv",
+            min_donor_observations=1,
+        )
+
+
+@pytest.mark.unit
+def test_per_donor_analysis_enforces_manifest_hash_and_contract(tmp_path, monkeypatch):
+    counts = tmp_path / "counts.tsv"
+    _write_counts(counts)
+    monkeypatch.setattr(cohort_analysis, "rust_fit_imbalance_dispersion", lambda *a, **k: None)
+    monkeypatch.setattr(cohort_analysis, "rust_analyze_imbalance_run", lambda *a, **k: None)
+    with pytest.raises(ValueError, match="requires a locked count bundle"):
+        cohort_analysis.run_per_donor_analysis(
+            counts,
+            tmp_path / "results.tsv",
+            unit="snv",
+            expected_manifest_sha256="0" * 64,
+        )
+    with pytest.raises(ValueError, match="unphased"):
+        run_ai_analysis(counts, scope="per-donor", unit="snv", phased=True)

--- a/tests/analysis/test_region_col_modes.py
+++ b/tests/analysis/test_region_col_modes.py
@@ -23,18 +23,15 @@ import pytest
 def _write_counts(path, *, with_region: bool = True):
     """Write a tiny phased count TSV (two het SNVs in one peak).
 
-    ``with_region=True`` emits the current 10-column layout carrying a ``region`` column;
+    ``with_region=True`` emits a count layout that carries a ``region`` column;
     ``with_region=False`` omits it. Only the header is consulted by ``WaspAnalysisData``.
     """
     if with_region:
-        header = "chrom\tpos0\tpos\tref\talt\tGT\tregion\tref_count\talt_count\tother_count\n"
-        rows = (
-            "chr1\t100\t101\tA\tG\t0|1\tpeakX\t10\t8\t0\n"
-            "chr1\t200\t201\tC\tT\t1|0\tpeakX\t7\t9\t0\n"
-        )
+        header = "chrom\tstart\tpos\tref\talt\tregion\tGT\tref_count\talt_count\tN\n"
+        rows = "chr1\t100\t101\tA\tG\tpeakX\t0|1\t10\t8\t18\nchr1\t200\t201\tC\tT\tpeakX\t1|0\t7\t9\t16\n"
     else:
-        header = "chrom\tpos0\tpos\tref\talt\tGT\tref_count\talt_count\tother_count\n"
-        rows = "chr1\t100\t101\tA\tG\t0|1\t10\t8\t0\nchr1\t200\t201\tC\tT\t1|0\t7\t9\t0\n"
+        header = "chrom\tstart\tpos\tref\talt\tGT\tref_count\talt_count\tN\n"
+        rows = "chr1\t100\t101\tA\tG\t0|1\t10\t8\t18\nchr1\t200\t201\tC\tT\t1|0\t7\t9\t16\n"
     path.write_text(header + rows)
     return path
 
@@ -59,6 +56,28 @@ def test_rust_feature_mode_groups_by_region(tmp_path):
     assert res[0]["region"] == "peakX"
     assert res[0]["snp_count"] == 2
     assert "mu" in res[0]  # phased model engaged
+
+
+@pytest.mark.rust
+def test_rust_run_api_reports_model_specific_dispersion(tmp_path):
+    """The independent-run API exposes scalar or linear fit metadata, never both."""
+    wasp2_rust = pytest.importorskip("wasp2_rust")
+    tsv = _write_counts(tmp_path / "counts.tsv")
+
+    single = wasp2_rust.analyze_imbalance_run(
+        str(tsv), min_count=0, pseudocount=1, region_col="region", method="single"
+    )
+    linear = wasp2_rust.analyze_imbalance_run(
+        str(tsv), min_count=0, pseudocount=1, region_col="region", method="linear"
+    )
+
+    assert single["rho"] is not None
+    assert single["linear_d1"] is None
+    assert single["linear_d2"] is None
+    assert linear["rho"] is None
+    assert linear["linear_d1"] is not None
+    assert linear["linear_d2"] is not None
+    assert linear["method"] == "linear"
 
 
 @pytest.mark.rust
@@ -134,31 +153,6 @@ def test_cli_forwards_phased_and_region_col(tmp_path, spy_rust):
     )
     assert spy_rust["kwargs"].get("phased") is True
     assert spy_rust["kwargs"].get("region_col") == "region"
-
-
-@pytest.mark.unit
-def test_cli_auto_detects_feature_column(tmp_path, spy_rust):
-    from analysis.run_analysis import run_ai_analysis
-
-    tsv = _write_counts(tmp_path / "counts.tsv", with_region=True)
-    run_ai_analysis(str(tsv), out_file=str(tmp_path / "out.tsv"))
-
-    assert spy_rust["kwargs"].get("region_col") == "region"
-
-
-@pytest.mark.unit
-def test_cli_does_not_group_bare_counts_by_gt_or_sample(tmp_path, spy_rust):
-    from analysis.run_analysis import run_ai_analysis
-
-    tsv = _write_counts(tmp_path / "counts.tsv", with_region=False)
-    lines = tsv.read_text().splitlines()
-    lines[0] += "\tsample"
-    lines[1:] = [f"{line}\tSAMPLE1" for line in lines[1:]]
-    tsv.write_text("\n".join(lines) + "\n")
-
-    run_ai_analysis(str(tsv), out_file=str(tmp_path / "out.tsv"))
-
-    assert spy_rust["kwargs"].get("region_col") is None
 
 
 @pytest.mark.unit

--- a/tests/counting/test_count_alleles.py
+++ b/tests/counting/test_count_alleles.py
@@ -44,3 +44,19 @@ def test_bulk_counting_preserves_counts_above_uint16(monkeypatch):
     assert result.schema["ref_count"] == pl.UInt32
     assert result.schema["alt_count"] == pl.UInt32
     assert result.schema["other_count"] == pl.UInt32
+
+
+@pytest.mark.unit
+def test_bulk_counting_rejects_multiple_alleles_at_one_position(monkeypatch):
+    monkeypatch.setattr(count_alleles, "RUST_AVAILABLE", True)
+    variants = pl.DataFrame(
+        {
+            "chrom": ["chr1", "chr1"],
+            "pos": [10, 10],
+            "ref": ["A", "A"],
+            "alt": ["G", "T"],
+        }
+    ).with_columns(pl.col("chrom").cast(pl.Categorical))
+
+    with pytest.raises(ValueError, match="biallelic positions only"):
+        count_alleles.make_count_df("sample.bam", variants)

--- a/tests/test_extension_version.py
+++ b/tests/test_extension_version.py
@@ -1,0 +1,7 @@
+import importlib.metadata
+
+import wasp2_rust
+
+
+def test_rust_extension_version_matches_distribution() -> None:
+    assert wasp2_rust.__version__ == importlib.metadata.version("wasp2")


### PR DESCRIPTION
## Summary

- Adds donor-local bulk allelic-imbalance orchestration for `single|linear × global|per-donor` inference.
- Keeps effect likelihoods and Benjamini-Hochberg correction donor-local. `global` shares only nuisance fits; `per-donor` fits nuisance parameters independently.
- Enforces unphased single-SNV testing while supporting separate phased and unphased peak-feature analysis.
- Aligns the Rust and Python APIs, type stubs, tests, documentation, changelog, citation metadata, and the `1.5.0` version surface.
- Rejects ambiguous multi-allelic count rows instead of coercing them into biallelic identities.

## Validation

- `make rust-test`: 126 passed, 0 failed, 7 ignored.
- `make test`: 236 passed, 0 failed, 27 skipped.
- `git diff --check origin/dev...HEAD`: passed.
- Gitleaks: no leaks found across all eight commits.

## Publication scope

- 19 source, test, documentation, and release-metadata files; no workflow, generated-analysis, or unrelated artifacts.
- No downstream SciLock analysis rerun.
- No merge, tag, package publication, or release action.